### PR TITLE
Release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipforge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipforge",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "ffmpeg-static": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipforge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Open-source AI video clipper — turn long videos into viral short clips (an Opus Clip alternative)",
   "main": "out/main/index.js",
   "author": "ClipForge Contributors",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps the app version to 0.2.0 for the first tagged release, so packaged builds and the in-app update checker identify as v0.2.0.

Release highlights (since 0.1.0):
- Smoother editor preview playback (coalesced seeks; no more random freezes after edits)
- Many more clips per video (~1 per minute target) with genre-aware endings that land, backed by an LLM ending-review pass
- Custom caption fonts (upload TTF/OTF, per-clip override, burned into exports)
- Branding watermark/logo with corner, size and opacity controls
- 8 new caption styles; B-roll off by default
- GPT-5 series analysis models (default `gpt-5.4-mini`)
- Update checks against GitHub releases (automatic on launch + manual in Settings)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

