### PR TITLE
Update checks work on the private repo via optional GitHub token

### DIFF
--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -71,12 +71,18 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
 
   const version = currentVersion()
   try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      // GitHub's API rejects requests without a User-Agent.
+      'User-Agent': `ClipForge/${version}`
+    }
+    // While the repository is private, unauthenticated requests 404; a token
+    // from the environment lets those installs see releases too.
+    const token = process.env.CLIPFORGE_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN
+    if (token) headers.Authorization = `Bearer ${token}`
+
     const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        // GitHub's API rejects requests without a User-Agent.
-        'User-Agent': `ClipForge/${version}`
-      },
+      headers,
       signal: AbortSignal.timeout(CHECK_TIMEOUT_MS)
     })
     if (res.status === 404) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
While publishing v0.2.0 I found that the repository is **private**, so the update checker's unauthenticated GitHub API call returns 404 and installs would always report "up to date" even though the v0.2.0 release exists.

- The check now attaches `Authorization: Bearer <token>` when `CLIPFORGE_GITHUB_TOKEN` (or `GITHUB_TOKEN`) is set in the environment, which makes releases visible for private repos. Without a token, behaviour is unchanged.
- No token is ever stored or logged; it is read from the environment per request.
- If the repo is made public later, the unauthenticated path works as-is and no token is needed.

Verified live against the real v0.2.0 release: unauthenticated → no release visible (GitHub 404 on private repos); with token → `latestVersion: "0.2.0"`, `updateAvailable: true`, release URL correct.

Testing: `npm run typecheck`, `npm run lint`, `npm run test` (79 tests) all pass, plus the live checks above.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

