### PR TITLE
Native glass UI on macOS: vibrancy, translucent surfaces, inset title bar

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,6 +44,7 @@ function createWindow(): void {
   // A floating window with margin around it, never edge-to-edge (and never
   // larger than the work area on small laptop displays).
   const { width, height } = initialWindowSize(screen.getPrimaryDisplay().workAreaSize)
+  const isMac = process.platform === 'darwin'
   const win = new BrowserWindow({
     width,
     height,
@@ -52,8 +53,20 @@ function createWindow(): void {
     center: true,
     show: false,
     autoHideMenuBar: true,
-    backgroundColor: '#09090b',
     title: 'ClipForge',
+    // macOS gets the native frosted-glass treatment: system vibrancy showing
+    // through a translucent shell (the renderer lightens its surfaces via the
+    // `mac-glass` body class), an inset title bar and our top bar as the drag
+    // region. Other platforms keep the solid dark background.
+    ...(isMac
+      ? {
+          backgroundColor: '#00000000',
+          vibrancy: 'under-window' as const,
+          visualEffectState: 'active' as const,
+          titleBarStyle: 'hiddenInset' as const,
+          trafficLightPosition: { x: 18, y: 20 }
+        }
+      : { backgroundColor: '#09090b' }),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: true,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -94,7 +94,10 @@ const api = {
   },
 
   /** Build a media:// URL the renderer can use in <video>/<img> tags. */
-  mediaUrl: (absolutePath: string): string => `media://file/${encodeURIComponent(absolutePath)}`
+  mediaUrl: (absolutePath: string): string => `media://file/${encodeURIComponent(absolutePath)}`,
+
+  /** OS platform, for platform-specific chrome (mac vibrancy, drag regions). */
+  platform: process.env.CLIPFORGE_FORCE_GLASS ? 'darwin' : process.platform
 }
 
 export type ClipForgeApi = typeof api

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -31,6 +31,9 @@ export default function App(): React.JSX.Element {
 
   useEffect(() => {
     void init()
+    // macOS renders with native vibrancy behind a translucent shell; the
+    // class switches the surface palette to translucent variants (index.css).
+    if (window.clipforge.platform === 'darwin') document.body.classList.add('mac-glass')
   }, [init])
 
   return (

--- a/src/renderer/src/components/TopBar.tsx
+++ b/src/renderer/src/components/TopBar.tsx
@@ -13,7 +13,7 @@ export default function TopBar(): React.JSX.Element {
   const showBack = screen === 'clips' || screen === 'editor'
 
   return (
-    <header className="flex h-14 shrink-0 items-center gap-3 border-b border-white/[0.06] bg-surface-950/70 px-4 backdrop-blur-xl">
+    <header className="app-topbar flex h-14 shrink-0 items-center gap-3 border-b border-white/[0.06] bg-surface-950/70 px-4 backdrop-blur-xl">
       {showBack ? (
         <button
           onClick={() => (screen === 'editor' ? closeEditor() : goHome())}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -48,6 +48,33 @@ body {
   overflow: hidden;
 }
 
+/*
+ * macOS glass: the window is created with native vibrancy and a transparent
+ * background, so the surface palette switches to translucent variants that
+ * let the system blur show through while keeping the same hierarchy. Video
+ * areas stay opaque black (bg-black) for accurate playback contrast.
+ */
+body.mac-glass {
+  --color-surface-950: rgba(9, 9, 11, 0.55);
+  --color-surface-900: rgba(17, 17, 18, 0.68);
+  --color-surface-850: rgba(22, 22, 23, 0.7);
+  --color-surface-800: rgba(28, 28, 30, 0.72);
+  --color-surface-700: rgba(58, 58, 64, 0.65);
+  --color-surface-600: rgba(82, 82, 90, 0.65);
+}
+
+/* The top bar doubles as the title bar under titleBarStyle: hiddenInset —
+   draggable, with room for the traffic lights on the left. */
+body.mac-glass .app-topbar {
+  -webkit-app-region: drag;
+  padding-left: 84px;
+}
+body.mac-glass .app-topbar button,
+body.mac-glass .app-topbar a,
+body.mac-glass .app-topbar input {
+  -webkit-app-region: no-drag;
+}
+
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On macOS the app now renders as a native glass window:

- The window is created with `vibrancy: 'under-window'` + a transparent background, so the system frosted-blur shows through the app shell.
- `titleBarStyle: 'hiddenInset'` removes the plain title bar; the app's top bar becomes the draggable title-bar region with left padding for the inset traffic lights.
- The renderer adds a `mac-glass` body class that swaps the surface palette (`--color-surface-*`) to translucent variants tuned to keep text contrast and panel hierarchy; video areas stay opaque black for accurate playback.
- Windows/Linux are completely untouched (solid background as before).

## Verification limits & evidence

True vibrancy blur only exists on macOS, which this environment cannot run — **needs a quick visual check on a real Mac** (`git pull && npm install && npm run build`, then look for frosted blur behind the UI, readable text, draggable top bar, sensible traffic-light placement).

What was verified here:

- A `CLIPFORGE_FORCE_GLASS` test hook activates the translucent palette + title-bar CSS on Linux. Verified live via CDP that the `mac-glass` class applies, the top bar gets its 84px inset, and body background switches to the translucent variant.
- A first palette pass (40–60% opacity) failed visual QA for contrast, so opacities were raised to 55–72% and re-checked across home/clips/editor/settings screenshots:

[Glass palette editor](https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmac_glass_palette_editor.png)
[Glass palette home](https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmac_glass_palette_home.png)

- Default (non-mac) run re-verified unchanged.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run test` (91 tests)
- Live CDP inspection + smoke screenshots with the forced palette; contrast QA pass


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

