### PR TITLE
One-click self-update for source checkouts: pull, rebuild, relaunch in-app

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -16,7 +16,7 @@ import { getTimeline } from './pipeline/timeline'
 import { renderClip } from './pipeline/render'
 import { generateSocialCaption } from './pipeline/socialCaption'
 import { addCustomFonts, listCustomFonts, removeCustomFont, renderFontsDir } from './fonts'
-import { checkForUpdates, downloadUpdate, installUpdate } from './updates'
+import { checkForUpdates, downloadUpdate, installUpdate, updateFromSource } from './updates'
 import { isMediaPathAllowed } from './mediaAccess'
 import { sanitizeFileName, uniqueOutputPath } from './exportPath'
 import { deleteProject, listProjects, loadProject, saveProject } from './projects'
@@ -312,6 +312,12 @@ export function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('updates:install', async () => installUpdate())
+
+  ipcMain.handle('updates:updateFromSource', async (event) => {
+    return updateFromSource((p) => {
+      if (!event.sender.isDestroyed()) event.sender.send('update:sourceProgress', p)
+    })
+  })
 
   ipcMain.handle('shell:showItemInFolder', async (_e, path: string) => {
     shell.showItemInFolder(path)

--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -1,6 +1,9 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { app } from 'electron'
 import { autoUpdater } from 'electron-updater'
-import type { UpdateCheckResult, UpdateDownloadProgress } from '@shared/types'
+import type { ImportProgress, UpdateCheckResult, UpdateDownloadProgress } from '@shared/types'
 
 /**
  * Update checking and in-app updating.
@@ -55,11 +58,23 @@ export function isAutoUpdateSupported(): boolean {
   return app?.isPackaged === true || process.env.CLIPFORGE_FORCE_DEV_UPDATES === '1'
 }
 
+/**
+ * True when this copy is a git checkout the app can update in place: pull,
+ * reinstall dependencies, rebuild, relaunch (the one-click update path for
+ * source installs, where a packaged-style swap is impossible).
+ */
+export function isSourceUpdateSupported(): boolean {
+  if (isAutoUpdateSupported()) return false
+  const root = app?.getAppPath?.()
+  return !!root && existsSync(join(root, '.git'))
+}
+
 /** Pure decision step, separated from the network fetch for tests. */
 export function evaluateUpdate(
   currentVersion: string,
   release: GithubRelease | null,
-  autoUpdateSupported = false
+  autoUpdateSupported = false,
+  sourceUpdateSupported = false
 ): UpdateCheckResult {
   const tag = release?.tag_name?.trim() || null
   const usable = tag !== null && !release?.draft && !release?.prerelease
@@ -70,6 +85,7 @@ export function evaluateUpdate(
     updateAvailable: latestVersion !== null && compareVersions(latestVersion, currentVersion) > 0,
     releaseUrl: (usable ? release?.html_url : null) ?? (latestVersion ? RELEASES_PAGE : null),
     autoUpdateSupported,
+    sourceUpdateSupported,
     error: null,
     checkedAt: Date.now()
   }
@@ -86,7 +102,8 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
     return evaluateUpdate(
       currentVersion(),
       { tag_name: fake, html_url: RELEASES_PAGE },
-      isAutoUpdateSupported()
+      isAutoUpdateSupported(),
+      isSourceUpdateSupported()
     )
   }
 
@@ -108,12 +125,17 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
     })
     if (res.status === 404) {
       // No published releases yet: nothing to update to.
-      return evaluateUpdate(version, null, isAutoUpdateSupported())
+      return evaluateUpdate(version, null, isAutoUpdateSupported(), isSourceUpdateSupported())
     }
     if (!res.ok) {
       throw new Error(`GitHub responded with HTTP ${res.status}`)
     }
-    return evaluateUpdate(version, (await res.json()) as GithubRelease, isAutoUpdateSupported())
+    return evaluateUpdate(
+      version,
+      (await res.json()) as GithubRelease,
+      isAutoUpdateSupported(),
+      isSourceUpdateSupported()
+    )
   } catch (err) {
     return {
       currentVersion: version,
@@ -121,6 +143,7 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
       updateAvailable: false,
       releaseUrl: null,
       autoUpdateSupported: isAutoUpdateSupported(),
+      sourceUpdateSupported: isSourceUpdateSupported(),
       error: `Could not check for updates: ${err instanceof Error ? err.message : String(err)}`,
       checkedAt: Date.now()
     }
@@ -184,4 +207,88 @@ export async function downloadUpdate(
 export function installUpdate(): void {
   if (!downloadedVersion) throw new Error('No downloaded update to install.')
   configureAutoUpdater().quitAndInstall()
+}
+
+function runStep(
+  cmd: string,
+  args: string[],
+  cwd: string
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, windowsHide: true })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (d: Buffer) => {
+      stdout += d.toString()
+    })
+    child.stderr.on('data', (d: Buffer) => {
+      stderr += d.toString()
+      if (stderr.length > 65536) stderr = stderr.slice(-32768)
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) return resolve(stdout)
+      const detail = stderr.split('\n').filter(Boolean).slice(-3).join(' ').trim()
+      reject(new Error(`"${cmd} ${args.join(' ')}" failed: ${detail || `exit code ${code}`}`))
+    })
+  })
+}
+
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+let sourceUpdateRunning = false
+
+/**
+ * One-click update for source checkouts: fast-forward the repo, reinstall
+ * dependencies, rebuild, then relaunch. Only manifest/build-cache churn is
+ * discarded automatically (the classic blocked-pull culprit); real local
+ * edits abort the update with a clear message instead of being destroyed.
+ */
+export async function updateFromSource(onProgress: (p: ImportProgress) => void): Promise<void> {
+  if (!isSourceUpdateSupported()) {
+    throw new Error('This copy is not a git checkout, so it cannot update itself this way.')
+  }
+  if (sourceUpdateRunning) throw new Error('An update is already running.')
+  sourceUpdateRunning = true
+  const root = app.getAppPath()
+  try {
+    onProgress({ progress: -1, message: 'Checking the local checkout…' })
+    const dirty = (await runStep('git', ['status', '--porcelain'], root))
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+    const churn = ['package-lock.json', 'package.json']
+    const discardable = dirty.filter((l) => churn.some((f) => l.endsWith(f)))
+    const blocking = dirty.filter(
+      (l) => !churn.some((f) => l.endsWith(f)) && !l.startsWith('??')
+    )
+    if (blocking.length > 0) {
+      throw new Error(
+        `You have local changes the update would overwrite (${blocking
+          .map((l) => l.split(/\s+/).pop())
+          .join(', ')}). Commit or stash them, then retry.`
+      )
+    }
+    // npm rewrites manifests on install; local churn there is safe to drop.
+    if (discardable.length > 0) {
+      await runStep('git', ['checkout', '--', 'package-lock.json', 'package.json'], root)
+    }
+
+    onProgress({ progress: -1, message: 'Pulling the latest code…' })
+    await runStep('git', ['pull', '--ff-only', 'origin', 'main'], root)
+
+    onProgress({ progress: -1, message: 'Installing dependencies…' })
+    await runStep(npmCmd, ['install', '--no-audit', '--no-fund'], root)
+
+    onProgress({ progress: -1, message: 'Rebuilding the app…' })
+    await runStep(npmCmd, ['run', 'build'], root)
+
+    onProgress({ progress: 1, message: 'Restarting…' })
+    // Let the IPC reply and the "Restarting…" frame land before swapping.
+    setTimeout(() => {
+      app.relaunch()
+      app.exit(0)
+    }, 800)
+  } finally {
+    sourceUpdateRunning = false
+  }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -63,6 +63,12 @@ const api = {
   checkForUpdates: (): Promise<UpdateCheckResult> => ipcRenderer.invoke('updates:check'),
   downloadUpdate: (): Promise<string> => ipcRenderer.invoke('updates:download'),
   installUpdate: (): Promise<void> => ipcRenderer.invoke('updates:install'),
+  updateFromSource: (): Promise<void> => ipcRenderer.invoke('updates:updateFromSource'),
+  onSourceUpdateProgress: (cb: (p: ImportProgress) => void): (() => void) => {
+    const listener = (_e: Electron.IpcRendererEvent, p: ImportProgress): void => cb(p)
+    ipcRenderer.on('update:sourceProgress', listener)
+    return () => ipcRenderer.removeListener('update:sourceProgress', listener)
+  },
   onUpdateDownloadProgress: (cb: (p: UpdateDownloadProgress) => void): (() => void) => {
     const listener = (_e: Electron.IpcRendererEvent, p: UpdateDownloadProgress): void => cb(p)
     ipcRenderer.on('update:downloadProgress', listener)

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -465,23 +465,21 @@ function UpdatesSection(): React.JSX.Element {
             onDownload={() => void downloadUpdate()}
             onInstall={() => void installUpdate()}
           />
+        ) : updateCheck.sourceUpdateSupported ? (
+          <SourceUpdater
+            latestVersion={updateCheck.latestVersion ?? ''}
+            releaseUrl={updateCheck.releaseUrl}
+          />
         ) : (
-          <>
-            <a
-              href={updateCheck.releaseUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/15 px-3 py-2.5 text-xs font-semibold text-emerald-400 transition hover:bg-emerald-500/25"
-            >
-              <Download size={13} />
-              Update to v{updateCheck.latestVersion} — open the release page
-            </a>
-            <p className="mt-1.5 text-[11px] leading-relaxed text-zinc-500">
-              This copy runs from a source checkout, so it can’t update itself. Grab the packaged
-              app from the release page, or update the checkout with{' '}
-              <span className="font-mono text-zinc-400">git pull && npm install && npm run build</span>.
-            </p>
-          </>
+          <a
+            href={updateCheck.releaseUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/15 px-3 py-2.5 text-xs font-semibold text-emerald-400 transition hover:bg-emerald-500/25"
+          >
+            <Download size={13} />
+            Update to v{updateCheck.latestVersion} — open the release page
+          </a>
         )
       ) : (
         updateCheck &&
@@ -513,6 +511,76 @@ function UpdatesSection(): React.JSX.Element {
       </button>
     </div>
   )
+}
+
+/**
+ * One-click update for source checkouts: the main process pulls, reinstalls,
+ * rebuilds and relaunches the app; this component just drives and narrates it.
+ */
+function SourceUpdater({
+  latestVersion,
+  releaseUrl
+}: {
+  latestVersion: string
+  releaseUrl: string
+}): React.JSX.Element {
+  const sourceUpdate = useStore((s) => s.sourceUpdate)
+  const updateFromSource = useStore((s) => s.updateFromSource)
+
+  switch (sourceUpdate.status) {
+    case 'running':
+      return (
+        <div className="mt-2.5 rounded-lg border border-surface-600 px-3 py-2.5">
+          <div className="flex items-center gap-2 text-xs text-zinc-300">
+            <Loader2 size={13} className="animate-spin" />
+            {sourceUpdate.message || 'Updating…'}
+          </div>
+          <p className="mt-1.5 text-[11px] leading-relaxed text-zinc-500">
+            Updating to v{latestVersion} — the app restarts by itself when done (about a minute).
+          </p>
+        </div>
+      )
+    case 'error':
+      return (
+        <>
+          <p className="mt-2.5 rounded-lg bg-red-500/10 px-3 py-2 text-xs leading-relaxed text-red-400">
+            {sourceUpdate.error}
+          </p>
+          <div className="mt-1.5 flex gap-1.5">
+            <button
+              onClick={() => void updateFromSource()}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-surface-600 px-3 py-2 text-xs font-medium text-zinc-300 transition hover:bg-surface-800"
+            >
+              <RefreshCw size={13} />
+              Retry
+            </button>
+            <a
+              href={releaseUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-surface-600 px-3 py-2 text-xs font-medium text-zinc-300 transition hover:bg-surface-800"
+            >
+              <ExternalLink size={13} />
+              Release page
+            </a>
+          </div>
+        </>
+      )
+    case 'idle':
+      return (
+        <button
+          onClick={() => void updateFromSource()}
+          className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/15 px-3 py-2.5 text-xs font-semibold text-emerald-400 transition hover:bg-emerald-500/25"
+        >
+          <Download size={13} />
+          Update to v{latestVersion} and restart
+        </button>
+      )
+    default: {
+      const exhaustive: never = sourceUpdate.status
+      return exhaustive
+    }
+  }
 }
 
 function UpdateInstaller({

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -66,6 +66,7 @@ interface AppState {
     progress: number
     error?: string
   }
+  sourceUpdate: { status: 'idle' | 'running' | 'error'; message: string; error?: string }
 
   init: () => Promise<void>
   refreshProjects: () => Promise<void>
@@ -98,6 +99,7 @@ interface AppState {
   checkForUpdates: (silent?: boolean) => Promise<void>
   downloadUpdate: () => Promise<void>
   installUpdate: () => Promise<void>
+  updateFromSource: () => Promise<void>
 }
 
 export const useStore = create<AppState>((set, get) => ({
@@ -116,6 +118,7 @@ export const useStore = create<AppState>((set, get) => ({
   updateCheck: null,
   checkingForUpdates: false,
   updateDownload: { status: 'idle', progress: 0 },
+  sourceUpdate: { status: 'idle', message: '' },
   captionBusy: {},
 
   init: async () => {
@@ -414,6 +417,31 @@ export const useStore = create<AppState>((set, get) => ({
 
   installUpdate: async () => {
     await window.clipforge.installUpdate()
+  },
+
+  updateFromSource: async () => {
+    if (get().sourceUpdate.status === 'running') return
+    set({ sourceUpdate: { status: 'running', message: 'Starting…' } })
+    const unsubscribe = window.clipforge.onSourceUpdateProgress((p) => {
+      if (get().sourceUpdate.status === 'running') {
+        set({ sourceUpdate: { status: 'running', message: p.message } })
+      }
+    })
+    try {
+      // On success the main process relaunches the app; this state only
+      // matters for the brief "Restarting…" moment.
+      await window.clipforge.updateFromSource()
+    } catch (err) {
+      set({
+        sourceUpdate: {
+          status: 'error',
+          message: '',
+          error: err instanceof Error ? cleanIpcError(err.message) : String(err)
+        }
+      })
+    } finally {
+      unsubscribe()
+    }
   }
 }))
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -234,6 +234,11 @@ export interface UpdateCheckResult {
    * pulling and rebuilding.
    */
   autoUpdateSupported: boolean
+  /**
+   * True when this copy is a git checkout the app can update in place by
+   * pulling and rebuilding itself (the one-click path for source installs).
+   */
+  sourceUpdateSupported: boolean
   /** Human-readable failure (offline, rate limited); null on success. */
   error: string | null
   checkedAt: number

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -45,12 +45,15 @@ describe('evaluateUpdate', () => {
     expect(res.releaseUrl).toBeNull()
   })
 
-  it('carries the auto-update capability flag through', () => {
+  it('carries the update capability flags through', () => {
     const release = { tag_name: 'v0.2.0' }
     expect(evaluateUpdate('0.1.0', release, true).autoUpdateSupported).toBe(true)
     expect(evaluateUpdate('0.1.0', release, false).autoUpdateSupported).toBe(false)
-    // Source checkouts default to no self-update.
-    expect(evaluateUpdate('0.1.0', release).autoUpdateSupported).toBe(false)
+    expect(evaluateUpdate('0.1.0', release, false, true).sourceUpdateSupported).toBe(true)
+    // Bare defaults: no self-update paths.
+    const bare = evaluateUpdate('0.1.0', release)
+    expect(bare.autoUpdateSupported).toBe(false)
+    expect(bare.sourceUpdateSupported).toBe(false)
   })
 
   it('ignores drafts and pre-releases', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Source installs (git checkouts — the default on macOS, where unsigned packaged apps cannot self-update) previously got a "open the release page" link. The update button now does the whole job itself:

- **"Update to vX and restart"** runs `git pull --ff-only origin main` → `npm install` → `npm run build`, streams stage progress into Settings ("Pulling the latest code…", "Installing dependencies…", "Rebuilding the app…"), then relaunches the app automatically.
- **Self-healing for the classic blocked pull**: npm manifest churn (`package.json`/`package-lock.json` modified locally by installs) is discarded automatically before pulling — the exact failure that blocked a real user update. Any *other* local edits abort with a clear "commit or stash" message listing the files, so real work is never destroyed.
- Errors surface in Settings with Retry + release-page fallback buttons.
- Capability detection: packaged builds keep the electron-updater download flow; git checkouts get the new source flow; only copies that are neither fall back to the plain release-page link. New `sourceUpdateSupported` flag on check results.

## Demo

Full end-to-end run: app at v0.5.0 (with a deliberately dirtied `package-lock.json` reproducing the user's blocked pull), one click → staged progress → self-relaunch → Settings reads v9.9.9 / up to date. Tested against a local clone with a fake v9.9.9 release commit:

[clipforge_source_one_click_update_and_relaunch.mp4](https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclipforge_source_one_click_update_and_relaunch.mp4)

[Update and restart button](https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_update_and_restart_button.webp)
[After update, v9.9.9 up to date](https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_after_source_update_v999.webp)

Post-run repo state confirmed: clone fast-forwarded to the new commit, version 9.9.9, clean working tree (dirty lockfile recovered).

## Testing

- `npm run typecheck`, `npm run lint`, `npm run test` (91 tests; capability-flag coverage updated)
- Live end-to-end GUI test under Xvfb described above, independently verified by a video-review pass


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

