### PR TITLE
Release v0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipforge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipforge",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipforge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Open-source AI video clipper — turn long videos into viral short clips (an Opus Clip alternative)",
   "main": "out/main/index.js",
   "author": "ClipForge Contributors",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Patch release for the auto-zoom shake fix.

- Auto zoom no longer shakes on steady footage: the export's zoom stage now uses subpixel (perspective) sampling instead of zoompan's whole-pixel stepping
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49442594-578e-4abb-9eb0-63fa1b8814c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49442594-578e-4abb-9eb0-63fa1b8814c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

