### PR TITLE
Fix source checkout auto-updater

### DIFF
--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import { app } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import type { ImportProgress, UpdateCheckResult, UpdateDownloadProgress } from '@shared/types'
@@ -11,9 +11,7 @@ import type { ImportProgress, UpdateCheckResult, UpdateDownloadProgress } from '
  * Discovery always goes through the GitHub Releases REST API (works in every
  * run mode and drives the "Update available" UI). Installing depends on how
  * the app runs: packaged builds (AppImage/NSIS) download and swap themselves
- * via electron-updater using the release's electron-builder metadata
- * (latest-linux.yml etc.); source checkouts cannot self-update, so the UI
- * links to the release page and suggests pulling instead.
+ * via electron-updater; source checkouts pull, rebuild and relaunch in place.
  */
 
 const REPO = 'JeremySNR/j-clip'
@@ -59,14 +57,49 @@ export function isAutoUpdateSupported(): boolean {
 }
 
 /**
+ * Walk upward from `start` until a `.git` directory/file is found.
+ * Exported for tests.
+ */
+export function findGitRoot(start: string): string | null {
+  let dir = resolve(start)
+  while (true) {
+    if (existsSync(join(dir, '.git'))) return dir
+    const parent = resolve(dir, '..')
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+/**
+ * Locate the ClipForge git checkout root. `app.getAppPath()` often points at
+ * `out/main` (next to the compiled main bundle), not the repo root where
+ * `.git` lives — so we walk upward from several likely starting points.
+ */
+export function resolveSourceRepoRoot(): string | null {
+  if (isAutoUpdateSupported()) return null
+  const starts = new Set<string>([process.cwd()])
+  const appPath = app?.getAppPath?.()
+  if (appPath) starts.add(appPath)
+  for (const start of starts) {
+    const root = findGitRoot(start)
+    if (!root || !existsSync(join(root, 'package.json'))) continue
+    try {
+      const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')) as { name?: string }
+      if (pkg.name === 'clipforge') return root
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return null
+}
+
+/**
  * True when this copy is a git checkout the app can update in place: pull,
  * reinstall dependencies, rebuild, relaunch (the one-click update path for
  * source installs, where a packaged-style swap is impossible).
  */
 export function isSourceUpdateSupported(): boolean {
-  if (isAutoUpdateSupported()) return false
-  const root = app?.getAppPath?.()
-  return !!root && existsSync(join(root, '.git'))
+  return !isAutoUpdateSupported()
 }
 
 /** Pure decision step, separated from the network fetch for tests. */
@@ -245,11 +278,16 @@ let sourceUpdateRunning = false
  */
 export async function updateFromSource(onProgress: (p: ImportProgress) => void): Promise<void> {
   if (!isSourceUpdateSupported()) {
-    throw new Error('This copy is not a git checkout, so it cannot update itself this way.')
+    throw new Error('Packaged installs update via download and restart, not git pull.')
+  }
+  const root = resolveSourceRepoRoot()
+  if (!root) {
+    throw new Error(
+      'This folder is not a git checkout (no .git directory found). Clone the repo with git clone, or download the AppImage from the releases page.'
+    )
   }
   if (sourceUpdateRunning) throw new Error('An update is already running.')
   sourceUpdateRunning = true
-  const root = app.getAppPath()
   try {
     onProgress({ progress: -1, message: 'Checking the local checkout…' })
     const dirty = (await runStep('git', ['status', '--porcelain'], root))
@@ -274,7 +312,7 @@ export async function updateFromSource(onProgress: (p: ImportProgress) => void):
     }
 
     onProgress({ progress: -1, message: 'Pulling the latest code…' })
-    await runStep('git', ['pull', '--ff-only', 'origin', 'main'], root)
+    await runStep('git', ['pull', '--ff-only'], root)
 
     onProgress({ progress: -1, message: 'Installing dependencies…' })
     await runStep(npmCmd, ['install', '--no-audit', '--no-fund'], root)

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -465,21 +465,11 @@ function UpdatesSection(): React.JSX.Element {
             onDownload={() => void downloadUpdate()}
             onInstall={() => void installUpdate()}
           />
-        ) : updateCheck.sourceUpdateSupported ? (
+        ) : (
           <SourceUpdater
             latestVersion={updateCheck.latestVersion ?? ''}
             releaseUrl={updateCheck.releaseUrl}
           />
-        ) : (
-          <a
-            href={updateCheck.releaseUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/15 px-3 py-2.5 text-xs font-semibold text-emerald-400 transition hover:bg-emerald-500/25"
-          >
-            <Download size={13} />
-            Update to v{updateCheck.latestVersion} — open the release page
-          </a>
         )
       ) : (
         updateCheck &&
@@ -568,13 +558,23 @@ function SourceUpdater({
       )
     case 'idle':
       return (
-        <button
-          onClick={() => void updateFromSource()}
-          className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/15 px-3 py-2.5 text-xs font-semibold text-emerald-400 transition hover:bg-emerald-500/25"
-        >
-          <Download size={13} />
-          Update to v{latestVersion} and restart
-        </button>
+        <>
+          <button
+            onClick={() => void updateFromSource()}
+            className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/15 px-3 py-2.5 text-xs font-semibold text-emerald-400 transition hover:bg-emerald-500/25"
+          >
+            <Download size={13} />
+            Update to v{latestVersion} and restart
+          </button>
+          <p className="mt-1.5 text-[11px] leading-relaxed text-zinc-500">
+            Pulls the latest code, reinstalls dependencies, rebuilds, and restarts the app (about a
+            minute). Needs a git checkout — zip downloads should use the{' '}
+            <a href={releaseUrl} target="_blank" rel="noreferrer" className="text-zinc-400 underline">
+              release page
+            </a>{' '}
+            instead.
+          </p>
+        </>
       )
     default: {
       const exhaustive: never = sourceUpdate.status

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -1,5 +1,25 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { compareVersions, evaluateUpdate } from '../src/main/updates'
+import { compareVersions, evaluateUpdate, findGitRoot, resolveSourceRepoRoot } from '../src/main/updates'
+
+describe('findGitRoot', () => {
+  it('walks up from a nested directory to the repo root', () => {
+    const root = findGitRoot(join(process.cwd(), 'out', 'main'))
+    expect(root).toBe(process.cwd())
+    expect(existsSync(join(root!, '.git'))).toBe(true)
+  })
+
+  it('returns null when no git directory exists above the start path', () => {
+    expect(findGitRoot('/tmp')).toBeNull()
+  })
+})
+
+describe('resolveSourceRepoRoot', () => {
+  it('finds the clipforge checkout from the workspace cwd', () => {
+    expect(resolveSourceRepoRoot()).toBe(process.cwd())
+  })
+})
 
 describe('compareVersions', () => {
   it('orders dotted versions numerically', () => {
@@ -50,7 +70,7 @@ describe('evaluateUpdate', () => {
     expect(evaluateUpdate('0.1.0', release, true).autoUpdateSupported).toBe(true)
     expect(evaluateUpdate('0.1.0', release, false).autoUpdateSupported).toBe(false)
     expect(evaluateUpdate('0.1.0', release, false, true).sourceUpdateSupported).toBe(true)
-    // Bare defaults: no self-update paths.
+    // Bare defaults: no self-update paths in the pure evaluator.
     const bare = evaluateUpdate('0.1.0', release)
     expect(bare.autoUpdateSupported).toBe(false)
     expect(bare.sourceUpdateSupported).toBe(false)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the source-checkout updater always falling back to "open the release page".

**Root cause:** `isSourceUpdateSupported()` only looked for `.git` directly under `app.getAppPath()`, which often points at `out/main` rather than the repo root.

**Fix:**
- Walk upward from `app.getAppPath()` and `process.cwd()` to find the ClipForge git root
- Non-packaged builds always show the one-click "Update and restart" button
- `git pull --ff-only` uses the current branch upstream instead of hardcoding `origin main`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

