### PR TITLE
Windows: fix DPAPI cookie import errors for Chrome/Edge Vimeo logins

### DIFF
--- a/src/main/pipeline/index.ts
+++ b/src/main/pipeline/index.ts
@@ -12,12 +12,15 @@ import { annotateEnergy } from './energy'
 import { assessClipVisuals, ensembleScore } from './visualScore'
 import { attachBroll } from './broll'
 import {
+  assertCookieAuthSupported,
   cookieCopyErrorHint,
+  cookieDpapiErrorHint,
   downloadUrlVideo,
   ensureYtDlp,
   fetchUrlMeta,
   isAuthError,
   isCookieCopyError,
+  isDpapiDecryptError,
   withSelfUpdateRetry,
   YtDlpError,
   type CookieAuthOptions
@@ -52,6 +55,7 @@ export async function createProjectFromUrl(
     cookiesFromBrowser: prefs.importCookiesBrowser || undefined,
     cookiesFile: prefs.importCookiesPath
   }
+  assertCookieAuthSupported(cookieOpts)
   onProgress({ progress: -1, message: 'Checking the video…' })
   const meta = await withSelfUpdateRetry(binPath, onProgress, () =>
     fetchUrlMeta(binPath, url, cookieOpts)
@@ -95,6 +99,9 @@ function rethrowWithLoginHint(
 ): (err: unknown) => never {
   return (err: unknown): never => {
     if (err instanceof YtDlpError) {
+      if (isDpapiDecryptError(err.message)) {
+        throw new YtDlpError(cookieDpapiErrorHint(hasCookiesFile))
+      }
       if (isCookieCopyError(err.message)) {
         throw new YtDlpError(cookieCopyErrorHint(browser, hasCookiesFile))
       }

--- a/src/main/pipeline/ytdlp.ts
+++ b/src/main/pipeline/ytdlp.ts
@@ -7,6 +7,7 @@ import { pipeline } from 'node:stream/promises'
 import type { ReadableStream as WebReadableStream } from 'node:stream/web'
 import { app } from 'electron'
 import type { BrowserCookieSource, ImportProgress } from '@shared/types'
+import { CHROMIUM_BROWSERS } from '@shared/cookies'
 import { FFMPEG_PATH } from './ffmpeg'
 
 /**
@@ -24,14 +25,6 @@ export class YtDlpError extends Error {
     this.name = 'YtDlpError'
   }
 }
-
-const CHROMIUM_BROWSERS = new Set<BrowserCookieSource>([
-  'chrome',
-  'edge',
-  'brave',
-  'opera',
-  'vivaldi'
-])
 
 function binaryName(): string {
   switch (process.platform) {
@@ -145,6 +138,35 @@ export function isCookieCopyError(message: string): boolean {
   return /could not copy chrome cookie database|permission denied.*cookies/i.test(message)
 }
 
+/** Windows Chromium v20+ app-bound encryption; yt-dlp cannot decrypt outside the browser. */
+export function isDpapiDecryptError(message: string): boolean {
+  return /failed to decrypt with dpapi|cannot decrypt v\d+ cookies|no key found/i.test(message)
+}
+
+export function cookieDpapiErrorHint(hasCookiesFile: boolean): string {
+  if (hasCookiesFile) {
+    return 'Your cookies file is set but the import still failed. Open the Vimeo video in your browser while signed in, re-export cookies with the Get cookies.txt LOCALLY extension, import the new file, and retry.'
+  }
+  return [
+    'Windows encrypts Chrome/Edge cookies so other apps cannot read them (this is a Chromium security change, not a ClipForge bug).',
+    'Use Import cookies file below: sign in to Vimeo in your browser, export with the Get cookies.txt LOCALLY extension, then import the .txt file.',
+    'Or pick Firefox in the browser list. Firefox cookies still work with browser login on Windows.'
+  ].join(' ')
+}
+
+/** Chromium on Windows uses DPAPI app-bound encryption; fail fast with a clear fix. */
+export function assertCookieAuthSupported(opts: CookieAuthOptions): void {
+  const hasFile = Boolean(opts.cookiesFile && existsSync(opts.cookiesFile))
+  if (
+    process.platform === 'win32' &&
+    opts.cookiesFromBrowser &&
+    CHROMIUM_BROWSERS.has(opts.cookiesFromBrowser) &&
+    !hasFile
+  ) {
+    throw new YtDlpError(cookieDpapiErrorHint(false))
+  }
+}
+
 export function cookieCopyErrorHint(browser: BrowserCookieSource, hasCookiesFile: boolean): string {
   if (hasCookiesFile) {
     return 'Your cookies file is set but the import still failed. Re-export it from the browser while signed in to the site (use the Get cookies.txt LOCALLY extension), then import the new file and retry.'
@@ -156,7 +178,7 @@ export function cookieCopyErrorHint(browser: BrowserCookieSource, hasCookiesFile
     parts.push(
       'Try Firefox in the browser picker (it usually works while open), fully quit Chrome and retry, or import a cookies.txt file instead.'
     )
-  } else {
+  } else if (browser) {
     parts.push(
       'Make sure you are signed in to the site in that browser, or import a cookies.txt file instead.'
     )

--- a/src/renderer/src/components/HomeScreen.tsx
+++ b/src/renderer/src/components/HomeScreen.tsx
@@ -15,6 +15,7 @@ import { useStore } from '../store'
 import { formatDuration, formatBytes } from '../lib/format'
 import MissingSourceBanner from './MissingSourceBanner'
 import type { BrowserCookieSource, ClipLengthPreference } from '@shared/types'
+import { isChromiumBrowser } from '@shared/cookies'
 
 const COOKIE_BROWSERS: Array<{ value: BrowserCookieSource; label: string }> = [
   { value: '', label: 'No login' },
@@ -186,6 +187,15 @@ function CookieBrowserPicker(): React.JSX.Element | null {
         </select>
       </div>
       <div className="flex flex-wrap items-center gap-2 text-[11px] text-zinc-500">
+        {window.clipforge.platform === 'win32' &&
+          isChromiumBrowser(settings.importCookiesBrowser) &&
+          !settings.hasImportCookiesFile && (
+            <p className="w-full rounded-lg bg-amber-500/10 px-2.5 py-2 text-amber-300">
+              On Windows, Chrome and Edge cookies cannot be read by other apps. Use{' '}
+              <strong>Import cookies file</strong> below (Get cookies.txt LOCALLY extension), or pick
+              Firefox in the list.
+            </p>
+          )}
         <span>Chromium browsers lock cookies while open. If that fails, import a cookies file instead:</span>
         {settings.hasImportCookiesFile ? (
           <>

--- a/src/shared/cookies.ts
+++ b/src/shared/cookies.ts
@@ -1,0 +1,13 @@
+import type { BrowserCookieSource } from './types'
+
+export const CHROMIUM_BROWSERS: ReadonlySet<BrowserCookieSource> = new Set([
+  'chrome',
+  'edge',
+  'brave',
+  'opera',
+  'vivaldi'
+])
+
+export function isChromiumBrowser(browser: BrowserCookieSource): boolean {
+  return CHROMIUM_BROWSERS.has(browser)
+}

--- a/tests/cookies.test.ts
+++ b/tests/cookies.test.ts
@@ -4,10 +4,13 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { isNetscapeCookiesFile } from '../src/main/cookies'
 import {
+  assertCookieAuthSupported,
   cookieArgs,
   cookieCopyErrorHint,
+  cookieDpapiErrorHint,
   isAuthError,
   isCookieCopyError,
+  isDpapiDecryptError,
   pluginArgs
 } from '../src/main/pipeline/ytdlp'
 
@@ -54,7 +57,25 @@ describe('ytdlp cookie helpers', () => {
 
   it('detects cookie copy failures and auth errors', () => {
     expect(isCookieCopyError('Could not copy Chrome cookie database')).toBe(true)
+    expect(isDpapiDecryptError('Failed to decrypt with DPAPI')).toBe(true)
     expect(isAuthError('HTTP Error 403: Forbidden')).toBe(true)
+  })
+
+  it('suggests cookies file import for DPAPI failures on Windows', () => {
+    const hint = cookieDpapiErrorHint(false)
+    expect(hint).toContain('Get cookies.txt LOCALLY')
+    expect(hint).toContain('Firefox')
+  })
+
+  it('blocks Chromium browser login on Windows before calling yt-dlp', () => {
+    const prev = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    try {
+      expect(() => assertCookieAuthSupported({ cookiesFromBrowser: 'chrome' })).toThrow(/DPAPI|encrypts Chrome/i)
+      expect(() => assertCookieAuthSupported({ cookiesFromBrowser: 'firefox' })).not.toThrow()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: prev })
+    }
   })
 
   it('suggests cookies file import for Chromium lock errors', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes `Failed to decrypt with DPAPI` when importing Vimeo/SSO URLs with Chrome/Edge on Windows.

Windows Chromium browsers use app-bound cookie encryption that yt-dlp cannot decrypt (yt-dlp #10927). This is not fixable from our side.

**Changes:**
- Fail fast on Windows when Chromium browser login is selected without a cookies file, with a clear message
- Amber warning in the import UI on Windows when Chrome/Edge is selected
- DPAPI errors from yt-dlp are rewritten with steps: cookies file export or Firefox

**Working paths on Windows:**
1. **Import cookies file** — sign in to Vimeo, export with Get cookies.txt LOCALLY, import in ClipForge
2. **Firefox** in the browser picker — `--cookies-from-browser firefox` still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71a837a4-4603-42d7-b7d4-0f01b068a650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

