### PR TITLE
Force dark mode, add drag-and-drop import, and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+# Builds installable apps and publishes them to GitHub Releases.
+#
+# Trigger it by pushing a version tag that matches package.json, e.g.:
+#   npm version patch      # bumps version + creates the tag
+#   git push --follow-tags # pushes the commit and the v0.5.5 tag
+#
+# electron-builder uploads the .dmg / .exe / .AppImage plus the update
+# manifests (latest*.yml) the in-app updater reads. Once a user has installed
+# any build, every later release installs itself automatically — no more
+# `npm run dev`, no manual re-sends.
+#
+# Uses the built-in GITHUB_TOKEN, so no extra secrets are required as long as
+# releases publish to this same repo (see the `publish` block in package.json).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Build and publish
+        run: npm run package -- --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The app is not code-signed yet: stop electron-builder from hunting
+          # for a Developer ID certificate (and failing) on the macOS runner.
+          CSC_IDENTITY_AUTO_DISCOVERY: false

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/JeremySNR/j-clip/releases/latest"><img src="https://img.shields.io/github/v/release/JeremySNR/j-clip?color=10b981&label=release" alt="Latest release" /></a>
-  <a href="https://github.com/JeremySNR/j-clip/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/JeremySNR/j-clip/ci.yml?branch=main&label=CI" alt="CI status" /></a>
+  <a href="https://github.com/JeremySNR/clip-forge/releases/latest"><img src="https://img.shields.io/github/v/release/JeremySNR/clip-forge?color=10b981&label=release" alt="Latest release" /></a>
+  <a href="https://github.com/JeremySNR/clip-forge/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/JeremySNR/clip-forge/ci.yml?branch=main&label=CI" alt="CI status" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license" /></a>
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey" alt="Platforms" />
-  <a href="https://github.com/JeremySNR/j-clip/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs welcome" /></a>
+  <a href="https://github.com/JeremySNR/clip-forge/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs welcome" /></a>
 </p>
 
 ---
@@ -69,14 +69,25 @@ Typical cost: **~$0.36/hour of video** for Whisper transcription plus a few cent
 ## Quick start
 
 ```bash
-git clone https://github.com/JeremySNR/j-clip.git
-cd j-clip
+git clone https://github.com/JeremySNR/clip-forge.git
+cd clip-forge
 npm install
 npm run dev        # development with hot reload
 npm run package    # distributable build (dmg / nsis / AppImage)
 ```
 
-You need **Node.js 20+** and an [OpenAI API key](https://platform.openai.com/api-keys). Enter it in the app and it gets stored encrypted with Electron `safeStorage`. FFmpeg is bundled, so there is nothing else to install. Prebuilt Linux AppImages are on the [releases page](https://github.com/JeremySNR/j-clip/releases/latest).
+### Publishing a release (for maintainers)
+
+Most people should just download the app from the [releases page](https://github.com/JeremySNR/clip-forge/releases/latest) — there's no need to run anything from source. To cut a new release, bump the version and push a tag; the [`Release` workflow](.github/workflows/release.yml) builds the macOS `.dmg`, Windows installer and Linux `AppImage` and publishes them, along with the update manifests the in-app updater reads:
+
+```bash
+npm version patch        # or minor / major — bumps package.json and creates the tag
+git push --follow-tags   # pushes the commit and the vX.Y.Z tag
+```
+
+Once a user has installed any build, later releases install themselves automatically. The macOS app is **not code-signed yet**, so on first launch the user right-clicks the app and chooses **Open** to get past Gatekeeper (a one-time step). Signing + notarization removes that prompt and is what enables fully silent macOS auto-updates — add an Apple Developer ID certificate and wire the signing secrets into the workflow when you're ready.
+
+You need **Node.js 20+** and an [OpenAI API key](https://platform.openai.com/api-keys). Enter it in the app and it gets stored encrypted with Electron `safeStorage`. FFmpeg is bundled, so there is nothing else to install. Prebuilt Linux AppImages are on the [releases page](https://github.com/JeremySNR/clip-forge/releases/latest).
 
 Everything except transcription and analysis runs locally. Rendering, face tracking, editing, zoom and export never leave your machine. Only extracted audio, transcripts and a few sampled frames go to the OpenAI API. Never the full video.
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "publish": {
       "provider": "github",
       "owner": "JeremySNR",
-      "repo": "j-clip"
+      "repo": "clip-forge"
     },
     "files": [
       "out/**"
@@ -80,8 +80,12 @@
       }
     ],
     "mac": {
-      "target": "dmg",
-      "category": "public.app-category.video"
+      "target": [
+        "dmg",
+        "zip"
+      ],
+      "category": "public.app-category.video",
+      "identity": null
     },
     "win": {
       "target": "nsis"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, protocol, screen, shell } from 'electron'
+import { app, BrowserWindow, nativeTheme, protocol, screen, shell } from 'electron'
 import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { registerIpcHandlers } from './ipc'
@@ -99,6 +99,12 @@ function createWindow(): void {
 }
 
 app.whenReady().then(() => {
+  // The UI is a dark, near-monochrome design and (on macOS) leans on native
+  // vibrancy showing through translucent surfaces. Under the system's light
+  // appearance that blur turns the window a washed-out grey, so we pin the
+  // whole app to dark regardless of the OS setting.
+  nativeTheme.themeSource = 'dark'
+
   protocol.handle('media', (request) => {
     const url = new URL(request.url)
     const filePath = decodeURIComponent(url.pathname.replace(/^\//, ''))

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,6 +9,7 @@ import type {
   Project,
   SettingsUpdate
 } from '@shared/types'
+import { VIDEO_EXTENSIONS } from '@shared/video'
 import { analyzeProject, createProject, createProjectFromUrl } from './pipeline'
 import { downloadGpuFfmpeg } from './pipeline/encoders'
 import { probeVideo } from './pipeline/ffmpeg'
@@ -39,9 +40,7 @@ export const EXPORT_CANCELLED_MESSAGE = 'Export cancelled'
 /** How far apart durations may be for a relinked file to count as the same video. */
 const RELINK_DURATION_TOLERANCE_SEC = 2
 
-const VIDEO_FILTERS = [
-  { name: 'Videos', extensions: ['mp4', 'mov', 'mkv', 'webm', 'avi', 'm4v', 'mpg', 'mpeg', 'wmv'] }
-]
+const VIDEO_FILTERS = [{ name: 'Videos', extensions: [...VIDEO_EXTENSIONS] }]
 
 async function pickVideoFile(sender: Electron.WebContents, title: string): Promise<string | null> {
   // Headless/CI hook (like CLIPFORGE_SMOKE): skip the native dialog.

--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -14,7 +14,7 @@ import type { ImportProgress, UpdateCheckResult, UpdateDownloadProgress } from '
  * via electron-updater; source checkouts pull, rebuild and relaunch in place.
  */
 
-const REPO = 'JeremySNR/j-clip'
+const REPO = 'JeremySNR/clip-forge'
 const RELEASES_PAGE = `https://github.com/${REPO}/releases/latest`
 const CHECK_TIMEOUT_MS = 10_000
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import type {
   AnalyzeOptions,
   AppSettings,
@@ -103,6 +103,13 @@ const api = {
 
   /** Build a media:// URL the renderer can use in <video>/<img> tags. */
   mediaUrl: (absolutePath: string): string => `media://file/${encodeURIComponent(absolutePath)}`,
+
+  /**
+   * Absolute path for a dropped File. Electron removed File.path under the
+   * sandbox, so drag-and-drop has to resolve the path through webUtils here in
+   * the preload rather than reading it off the File in the renderer.
+   */
+  pathForFile: (file: File): string => webUtils.getPathForFile(file),
 
   /** OS platform, for platform-specific chrome (mac vibrancy, drag regions). */
   platform: process.env.CLIPFORGE_FORCE_GLASS ? 'darwin' : process.platform

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -34,6 +34,16 @@ export default function App(): React.JSX.Element {
     // macOS renders with native vibrancy behind a translucent shell; the
     // class switches the surface palette to translucent variants (index.css).
     if (window.clipforge.platform === 'darwin') document.body.classList.add('mac-glass')
+
+    // Dropping a file anywhere outside a designated drop zone would otherwise
+    // make Chromium navigate the window to that file and blow away the app.
+    const preventNav = (e: DragEvent): void => e.preventDefault()
+    window.addEventListener('dragover', preventNav)
+    window.addEventListener('drop', preventNav)
+    return () => {
+      window.removeEventListener('dragover', preventNav)
+      window.removeEventListener('drop', preventNav)
+    }
   }, [init])
 
   return (

--- a/src/renderer/src/components/HomeScreen.tsx
+++ b/src/renderer/src/components/HomeScreen.tsx
@@ -16,6 +16,7 @@ import { formatDuration, formatBytes } from '../lib/format'
 import MissingSourceBanner from './MissingSourceBanner'
 import type { BrowserCookieSource, ClipLengthPreference } from '@shared/types'
 import { isChromiumBrowser } from '@shared/cookies'
+import { isVideoFile } from '@shared/video'
 
 const COOKIE_BROWSERS: Array<{ value: BrowserCookieSource; label: string }> = [
   { value: '', label: 'No login' },
@@ -52,14 +53,36 @@ export default function HomeScreen(): React.JSX.Element {
 
 function ImportHero(): React.JSX.Element {
   const importVideo = useStore((s) => s.importVideo)
+  const importVideoFromPath = useStore((s) => s.importVideoFromPath)
   const importVideoFromUrl = useStore((s) => s.importVideoFromUrl)
   const importProgress = useStore((s) => s.importProgress)
+  const setPipelineError = (msg: string | null): void => useStore.setState({ pipelineError: msg })
   const pipelineError = useStore((s) => s.pipelineError)
   const [busy, setBusy] = useState(false)
+  const [dragOver, setDragOver] = useState(false)
   const [url, setUrl] = useState('')
 
   const importing = importProgress !== null
   const canSubmitUrl = /^https?:\/\/\S+$/.test(url.trim()) && !importing
+  const disabled = busy || importing
+
+  const handleDrop = (e: React.DragEvent): void => {
+    e.preventDefault()
+    setDragOver(false)
+    if (disabled) return
+    const file = e.dataTransfer.files[0]
+    if (!file) return
+    if (!isVideoFile(file.name)) {
+      setPipelineError(`"${file.name}" is not a supported video file (MP4, MOV, MKV, WEBM and more).`)
+      return
+    }
+    const path = window.clipforge.pathForFile(file)
+    if (!path) {
+      setPipelineError('Could not read that file from disk. Try choosing it instead.')
+      return
+    }
+    void importVideoFromPath(path)
+  }
 
   return (
     <div className="flex flex-col items-center pb-4 pt-8 text-center">
@@ -90,14 +113,28 @@ function ImportHero(): React.JSX.Element {
             setBusy(false)
           }
         }}
-        disabled={busy || importing}
-        className="mt-8 flex w-full max-w-xl cursor-pointer flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-surface-600 bg-white/[0.02] px-8 py-12 backdrop-blur transition hover:border-white/25 hover:bg-white/[0.04] disabled:opacity-60"
+        onDragOver={(e) => {
+          e.preventDefault()
+          if (!disabled) setDragOver(true)
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+        disabled={disabled}
+        className={`mt-8 flex w-full max-w-xl cursor-pointer flex-col items-center gap-3 rounded-2xl border-2 border-dashed bg-white/[0.02] px-8 py-12 backdrop-blur transition disabled:opacity-60 ${
+          dragOver
+            ? 'border-white/40 bg-white/[0.06]'
+            : 'border-surface-600 hover:border-white/25 hover:bg-white/[0.04]'
+        }`}
       >
         <div className="flex h-14 w-14 items-center justify-center rounded-full border border-white/10 bg-white/[0.05]">
           <Upload size={24} className="text-zinc-200" />
         </div>
         <div className="text-[15px] font-semibold">
-          {busy ? 'Reading video…' : 'Choose a video to clip'}
+          {busy
+            ? 'Reading video…'
+            : dragOver
+              ? 'Drop the video to start'
+              : 'Drag a video here, or click to choose'}
         </div>
         <div className="text-xs text-zinc-500">MP4, MOV, MKV, WEBM and more</div>
       </button>

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -71,6 +71,7 @@ interface AppState {
   init: () => Promise<void>
   refreshProjects: () => Promise<void>
   importVideo: () => Promise<void>
+  importVideoFromPath: (path: string) => Promise<void>
   importVideoFromUrl: (url: string) => Promise<void>
   openProject: (id: string) => Promise<void>
   deleteProject: (id: string) => Promise<void>
@@ -153,9 +154,17 @@ export const useStore = create<AppState>((set, get) => ({
   importVideo: async () => {
     const path = await window.clipforge.selectVideo()
     if (!path) return
-    const project = await window.clipforge.createProject(path)
-    set({ project, screen: 'home', pipelineError: null })
-    await get().refreshProjects()
+    await get().importVideoFromPath(path)
+  },
+
+  importVideoFromPath: async (path) => {
+    try {
+      const project = await window.clipforge.createProject(path)
+      set({ project, screen: 'home', pipelineError: null })
+      await get().refreshProjects()
+    } catch (err) {
+      set({ pipelineError: err instanceof Error ? cleanIpcError(err.message) : String(err) })
+    }
   },
 
   importVideoFromUrl: async (url) => {

--- a/src/shared/video.ts
+++ b/src/shared/video.ts
@@ -1,0 +1,20 @@
+/** Video container extensions ClipForge accepts, without the leading dot. */
+export const VIDEO_EXTENSIONS = [
+  'mp4',
+  'mov',
+  'mkv',
+  'webm',
+  'avi',
+  'm4v',
+  'mpg',
+  'mpeg',
+  'wmv'
+] as const
+
+/** True when a file path/name has one of the accepted video extensions. */
+export function isVideoFile(pathOrName: string): boolean {
+  const dot = pathOrName.lastIndexOf('.')
+  if (dot === -1) return false
+  const ext = pathOrName.slice(dot + 1).toLowerCase()
+  return (VIDEO_EXTENSIONS as readonly string[]).includes(ext)
+}


### PR DESCRIPTION
Addresses three issues a non-technical macOS user hit.

## Force dark mode
Pins `nativeTheme.themeSource = 'dark'` so the app renders dark regardless of the OS appearance. In macOS light mode the native `under-window` vibrancy showed through as a washed-out grey; forcing dark fixes it while keeping the frosted-glass shell.

## Drag-and-drop import
The home screen now accepts a video dropped onto it, not just click-to-browse. The dropped file's path is resolved through `webUtils.getPathForFile` in the preload (`File.path` is gone under the sandbox), validated against a shared video-extension list (`src/shared/video.ts`, also now the single source of truth for the file dialog filter), then imported. A window-level `dragover`/`drop` guard stops a stray drop from navigating the window away. Click-to-choose is unchanged.

## Release automation (no more `npm run dev`)
The app already had a full in-app auto-updater but nothing produced downloadable builds. Adds a **Release** workflow (`.github/workflows/release.yml`) that builds the macOS `.dmg` (plus Windows/Linux) and publishes them — with the auto-update manifests — to GitHub Releases on a version tag. Users download once; later releases install themselves.

To make this work with zero extra secrets, the release repo is aligned across `package.json`, `src/main/updates.ts` and the README from the stale `JeremySNR/j-clip` to the actual repo `JeremySNR/clip-forge`, so publishing uses the built-in Actions token and the updater checks the same repo releases land in. Also adds a mac `zip` target (needed by the updater feed) and disables code signing for now — the README documents the one-time Gatekeeper right-click → Open step, and that signing + notarization is what enables silent macOS auto-updates later.

## Verification
`npm run typecheck`, `npm run lint`, `npm test` (105 passing) and a production `npm run build` all pass. The GUI wasn't launched here because this environment's proxy blocks the bundled ffmpeg binary download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NpcWHVsZoy48iXTCX4WWw

---
_Generated by [Claude Code](https://claude.ai/code/session_018NpcWHVsZoy48iXTCX4WWw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UX, CI packaging, and repo metadata; no auth or pipeline logic changes beyond shared extension lists and import path handling.
> 
> **Overview**
> Pins **`nativeTheme.themeSource = 'dark'`** so macOS light mode no longer washes out the vibrancy shell.
> 
> **Home import** accepts drag-and-drop: paths come from **`webUtils.getPathForFile`** in preload, extensions are validated via new **`src/shared/video.ts`** (also used for the file dialog), and **`importVideoFromPath`** centralizes project creation with error handling. A window-level **`dragover`/`drop`** guard stops stray drops from navigating the app away.
> 
> Adds a **Release** GitHub Actions workflow that builds and publishes macOS/Windows/Linux on **`v*`** tags with **`GITHUB_TOKEN`**. Aligns publish/updater/README from **`j-clip`** to **`clip-forge`**, adds a mac **`zip`** target for the updater, and disables code signing for now (**`identity: null`**, **`CSC_IDENTITY_AUTO_DISCOVERY: false`**). README documents tag-based releases and the Gatekeeper workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835b0267d964a1ddd26ed357affe213f7b47a8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->