### PR TITLE
Speaker reframing, transcription language, and tighten-cut fixes

### DIFF
--- a/scripts/test-broll.ts
+++ b/scripts/test-broll.ts
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
 
   console.log('3. Transcribing…')
   const chunks = await extractAudioChunks(source, join(WORK, 'audio'), info.durationSec)
-  const transcript = await transcribeChunks(API_KEY, 'whisper-1', chunks)
+  const transcript = await transcribeChunks(API_KEY, 'whisper-1', chunks, 'en')
   const text = transcript.segments.map((s) => s.text).join(' ')
   assert.ok(/yoda/i.test(text), 'transcript should mention Yoda')
 

--- a/scripts/test-e2e.ts
+++ b/scripts/test-e2e.ts
@@ -65,7 +65,7 @@ async function main(): Promise<void> {
   const chunks = await extractAudioChunks(source, join(WORK, 'audio'), info.durationSec)
 
   console.log('4. Transcribing with Whisper…')
-  const transcript = await transcribeChunks(API_KEY, 'whisper-1', chunks)
+  const transcript = await transcribeChunks(API_KEY, 'whisper-1', chunks, 'en')
   assert.ok(transcript.segments.length > 0, 'no transcript segments')
   const wordCount = transcript.segments.reduce((n, s) => n + s.words.length, 0)
   assert.ok(wordCount > 100, `too few words: ${wordCount}`)

--- a/scripts/test-youtube.ts
+++ b/scripts/test-youtube.ts
@@ -102,7 +102,7 @@ async function main(): Promise<void> {
 
   console.log('5. Transcribing…')
   const chunks = await extractAudioChunks(videoPath, join(WORK, 'audio'), info.durationSec)
-  const transcript = await transcribeChunks(apiKey, 'whisper-1', chunks)
+  const transcript = await transcribeChunks(apiKey, 'whisper-1', chunks, 'en')
   const words = transcript.segments.reduce((n, s) => n + s.words.length, 0)
   assert.ok(words > 10, `too few words transcribed: ${words}`)
   // Catches chunk-offset stitching bugs: timestamps must span the whole video.

--- a/src/main/pipeline/faces.ts
+++ b/src/main/pipeline/faces.ts
@@ -220,10 +220,14 @@ function trackRun(
   let shiftRun = 0
 
   const emit = (fromFrame: number): void => {
-    const mean = segmentValues.reduce((a, b) => a + b, 0) / segmentValues.length
+    // Median, not mean: a couple of transition frames must not drag the crop
+    // to an in-between position (which looks like the frame "searching" for
+    // the face). The median sits on the face the segment actually settled on.
+    const sorted = [...segmentValues].sort((a, b) => a - b)
+    const median = sorted[Math.floor(sorted.length / 2)]
     out.push({
       t: clipStartSec + (runStartFrame + fromFrame) / SAMPLE_FPS,
-      x: Math.min(1, Math.max(0, mean))
+      x: Math.min(1, Math.max(0, median))
     })
   }
 

--- a/src/main/pipeline/index.ts
+++ b/src/main/pipeline/index.ts
@@ -159,6 +159,7 @@ export async function analyzeProject(
         apiKey,
         settings.transcriptionModel,
         chunks,
+        settings.transcriptionLanguage,
         (f) =>
           onProgress({
             stage: 'transcribe',

--- a/src/main/pipeline/openai.ts
+++ b/src/main/pipeline/openai.ts
@@ -99,6 +99,12 @@ export interface WhisperResponse {
 export interface TranscribeFileOptions {
   /** Trailing text of the previous chunk, for cross-chunk context continuity. */
   contextPrompt?: string
+  /**
+   * ISO-639-1 language code (e.g. 'en'). When set, Whisper transcribes in that
+   * language instead of auto-detecting — which avoids it occasionally guessing
+   * the wrong language. Omit or pass 'auto' to let Whisper detect.
+   */
+  language?: string
   signal?: AbortSignal
 }
 
@@ -118,6 +124,7 @@ export async function transcribeAudioFile(
       form.append('timestamp_granularities[]', 'word')
       form.append('timestamp_granularities[]', 'segment')
       if (opts.contextPrompt) form.append('prompt', opts.contextPrompt)
+      if (opts.language && opts.language !== 'auto') form.append('language', opts.language)
 
       const res = await fetch(`${API_BASE}/audio/transcriptions`, {
         method: 'POST',

--- a/src/main/pipeline/speaker.ts
+++ b/src/main/pipeline/speaker.ts
@@ -27,22 +27,25 @@ export function iou(a: FaceBox, b: FaceBox): number {
 }
 
 /**
- * Mean absolute RGB difference between two frames over the mouth region
- * (lower third) of a face box. Frames are raw rgb24 buffers of w×h pixels;
- * box coordinates are normalised 0..1.
+ * Mean absolute RGB difference between two frames over a horizontal band of a
+ * face box (band fractions measured from the top of the box downward). Frames
+ * are raw rgb24 buffers of w×h pixels; box coordinates are normalised 0..1.
  */
-export function mouthActivity(
+function regionMotion(
   prev: Buffer,
   cur: Buffer,
   box: FaceBox,
   w: number,
-  h: number
+  h: number,
+  fromFrac: number,
+  toFrac: number
 ): number {
   const clamp = (v: number, max: number): number => Math.max(0, Math.min(max, v))
+  const boxH = box.y2 - box.y1
   const px1 = clamp(Math.floor(box.x1 * w), w - 1)
   const px2 = clamp(Math.ceil(box.x2 * w), w)
-  const py1 = clamp(Math.floor((box.y1 + (box.y2 - box.y1) * 0.62) * h), h - 1)
-  const py2 = clamp(Math.ceil(box.y2 * h), h)
+  const py1 = clamp(Math.floor((box.y1 + boxH * fromFrac) * h), h - 1)
+  const py2 = clamp(Math.ceil((box.y1 + boxH * toFrac) * h), h)
   let sum = 0
   let count = 0
   for (let y = py1; y < py2; y += 1) {
@@ -56,6 +59,26 @@ export function mouthActivity(
   return count === 0 ? 0 : sum / count
 }
 
+/**
+ * Visual speech signal for one face: how much the mouth region (lower ~38% of
+ * the box) moves *relative to* the upper face (eyes/brow). Subtracting the
+ * upper-face motion cancels whole-head movement — a nodding or gesturing
+ * listener moves both regions equally and scores ~0, while a talking mouth
+ * moves far more than the brow. This is what keeps the crop on the person
+ * actually speaking rather than whoever happens to be moving.
+ */
+export function mouthActivity(
+  prev: Buffer,
+  cur: Buffer,
+  box: FaceBox,
+  w: number,
+  h: number
+): number {
+  const mouth = regionMotion(prev, cur, box, w, h, 0.62, 1)
+  const upper = regionMotion(prev, cur, box, w, h, 0.05, 0.45)
+  return Math.max(0, mouth - upper)
+}
+
 const TRACK_MATCH_IOU = 0.25
 const ACTIVITY_EMA_ALPHA = 0.4
 /** A rival must out-talk the current speaker by this factor… */
@@ -66,6 +89,12 @@ const SPEAKER_SWITCH_FRAMES = 2
 const MIN_SWITCH_ACTIVITY = 1.0
 /** Keep a briefly undetected track alive for this many frames. */
 const TRACK_MAX_MISSED = 2
+/**
+ * After a switch, hold the new speaker for at least this many frames before
+ * switching again. Stops the focus ping-ponging between two people who trade
+ * off quickly — each cut then reads as a deliberate camera switch.
+ */
+const SWITCH_COOLDOWN_FRAMES = 3
 
 interface Track {
   box: FaceBox
@@ -100,6 +129,9 @@ export function chooseFocusCentres(
   let speaker: Track | null = null
   let challenger: Track | null = null
   let challengerStreak = 0
+  let cooldown = 0
+  /** Last committed speaker centre, for continuity when a track is lost. */
+  let lastCentre: number | null = null
   const centres: Array<number | null> = []
   const switchCuts: number[] = []
 
@@ -108,6 +140,8 @@ export function chooseFocusCentres(
     speaker = null
     challenger = null
     challengerStreak = 0
+    cooldown = 0
+    lastCentre = null
   }
 
   for (let f = 0; f < facesPerFrame.length; f++) {
@@ -155,9 +189,20 @@ export function chooseFocusCentres(
       continue
     }
 
+    if (cooldown > 0) cooldown--
+
     if (!speaker || !tracks.includes(speaker)) {
-      // (Re)acquire: most active track, size-weighted on a tie/at rest.
-      speaker = tracks.reduce((a, b) => (b.ema + weight(b) > a.ema + weight(a) ? b : a))
+      // (Re)acquire. When we had a speaker (lastCentre known) but lost the
+      // track to detection jitter, prefer the track closest to where the
+      // speaker just was — continuity over jumping to the biggest face. On a
+      // cold start pick the most active, size-weighted at rest.
+      if (lastCentre !== null) {
+        speaker = tracks.reduce((a, b) =>
+          Math.abs(b.centre - lastCentre!) < Math.abs(a.centre - lastCentre!) ? b : a
+        )
+      } else {
+        speaker = tracks.reduce((a, b) => (b.ema + weight(b) > a.ema + weight(a) ? b : a))
+      }
       challenger = null
       challengerStreak = 0
     } else {
@@ -165,6 +210,7 @@ export function chooseFocusCentres(
       const rival =
         rivals.length > 0 ? rivals.reduce((a, b) => (b.ema > a.ema ? b : a)) : null
       if (
+        cooldown === 0 &&
         rival &&
         rival.ema > MIN_SWITCH_ACTIVITY &&
         rival.ema > speaker.ema * SPEAKER_SWITCH_RATIO
@@ -179,6 +225,7 @@ export function chooseFocusCentres(
           switchCuts.push(f)
           challenger = null
           challengerStreak = 0
+          cooldown = SWITCH_COOLDOWN_FRAMES
         }
       } else {
         challenger = null
@@ -186,6 +233,7 @@ export function chooseFocusCentres(
       }
     }
 
+    lastCentre = speaker.centre
     centres.push(speaker.centre)
   }
 

--- a/src/main/pipeline/transcribe.ts
+++ b/src/main/pipeline/transcribe.ts
@@ -94,6 +94,7 @@ export async function transcribeChunks(
   apiKey: string,
   model: string,
   chunks: AudioChunk[],
+  language: string,
   onProgress?: (fraction: number) => void,
   signal?: AbortSignal
 ): Promise<Transcript> {
@@ -105,6 +106,7 @@ export async function transcribeChunks(
     const chunk = chunks[i]
     const res = await transcribeAudioFile(apiKey, chunk.path, model, {
       contextPrompt: previousTail || undefined,
+      language,
       signal
     })
     previousTail = (res.text ?? '').slice(-600)

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -16,6 +16,8 @@ interface StoredSettings {
   /** Base64 of safeStorage-encrypted key, or plain 'plain:'-prefixed fallback. */
   apiKeyEncrypted: string
   transcriptionModel: string
+  /** ISO-639-1 language code forced on Whisper, or 'auto' to auto-detect. */
+  transcriptionLanguage: string
   analysisModel: string
   encoder: EncoderPreference
   quality: QualityPreference
@@ -34,6 +36,11 @@ const DEFAULT_BRANDING: BrandingSettings = {
 const DEFAULTS: StoredSettings = {
   apiKeyEncrypted: '',
   transcriptionModel: 'whisper-1',
+  // Default to English rather than Whisper's auto-detect: the app is
+  // English-first, and auto-detect occasionally mislabels English speech as a
+  // similar-sounding language (e.g. Welsh). Users of other languages can pick
+  // theirs — or 'auto' — in Settings.
+  transcriptionLanguage: 'en',
   analysisModel: 'gpt-5.4-mini',
   encoder: 'auto',
   quality: 'standard',
@@ -108,6 +115,7 @@ export async function getSettings(): Promise<AppSettings> {
     apiKeyMasked: key.length > 8 ? `${key.slice(0, 5)}…${key.slice(-4)}` : key ? '•••' : '',
     keyStorageSecure: safeStorage.isEncryptionAvailable(),
     transcriptionModel: s.transcriptionModel,
+    transcriptionLanguage: s.transcriptionLanguage,
     analysisModel: s.analysisModel,
     encoder: s.encoder,
     quality: s.quality,
@@ -142,9 +150,17 @@ export function getExportPreferences(): { encoder: EncoderPreference; quality: Q
 }
 
 /** Synchronous access to the stored model preferences (no GPU probe). */
-export function getModelPreferences(): { transcriptionModel: string; analysisModel: string } {
+export function getModelPreferences(): {
+  transcriptionModel: string
+  transcriptionLanguage: string
+  analysisModel: string
+} {
   const s = load()
-  return { transcriptionModel: s.transcriptionModel, analysisModel: s.analysisModel }
+  return {
+    transcriptionModel: s.transcriptionModel,
+    transcriptionLanguage: s.transcriptionLanguage,
+    analysisModel: s.analysisModel
+  }
 }
 
 export async function updateSettings(update: SettingsUpdate): Promise<AppSettings> {
@@ -152,6 +168,9 @@ export async function updateSettings(update: SettingsUpdate): Promise<AppSetting
   if (update.apiKey !== undefined) s.apiKeyEncrypted = encryptKey(update.apiKey.trim())
   if (update.transcriptionModel !== undefined && update.transcriptionModel.trim()) {
     s.transcriptionModel = update.transcriptionModel.trim()
+  }
+  if (update.transcriptionLanguage !== undefined && update.transcriptionLanguage.trim()) {
+    s.transcriptionLanguage = update.transcriptionLanguage.trim()
   }
   if (update.analysisModel !== undefined && update.analysisModel.trim()) {
     s.analysisModel = update.analysisModel.trim()

--- a/src/renderer/src/components/HomeScreen.tsx
+++ b/src/renderer/src/components/HomeScreen.tsx
@@ -63,8 +63,8 @@ function ImportHero(): React.JSX.Element {
   const [url, setUrl] = useState('')
 
   const importing = importProgress !== null
-  const canSubmitUrl = /^https?:\/\/\S+$/.test(url.trim()) && !importing
   const disabled = busy || importing
+  const canSubmitUrl = /^https?:\/\/\S+$/.test(url.trim()) && !disabled
 
   const handleDrop = (e: React.DragEvent): void => {
     e.preventDefault()
@@ -81,7 +81,8 @@ function ImportHero(): React.JSX.Element {
       setPipelineError('Could not read that file from disk. Try choosing it instead.')
       return
     }
-    void importVideoFromPath(path)
+    setBusy(true)
+    void importVideoFromPath(path).finally(() => setBusy(false))
   }
 
   return (

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -13,6 +13,7 @@ import {
   Type,
   Zap,
   Download,
+  Languages,
   Loader2
 } from 'lucide-react'
 import { useStore } from '../store'
@@ -24,6 +25,26 @@ import type {
 } from '@shared/types'
 
 const ANALYSIS_MODELS = ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-4o-mini']
+
+/** Whisper transcription languages. 'auto' lets Whisper detect per video. */
+const TRANSCRIPTION_LANGUAGES: Array<{ value: string; label: string }> = [
+  { value: 'en', label: 'English' },
+  { value: 'auto', label: 'Auto-detect' },
+  { value: 'cy', label: 'Welsh' },
+  { value: 'es', label: 'Spanish' },
+  { value: 'fr', label: 'French' },
+  { value: 'de', label: 'German' },
+  { value: 'it', label: 'Italian' },
+  { value: 'pt', label: 'Portuguese' },
+  { value: 'nl', label: 'Dutch' },
+  { value: 'pl', label: 'Polish' },
+  { value: 'ru', label: 'Russian' },
+  { value: 'ja', label: 'Japanese' },
+  { value: 'zh', label: 'Chinese' },
+  { value: 'ko', label: 'Korean' },
+  { value: 'hi', label: 'Hindi' },
+  { value: 'ar', label: 'Arabic' }
+]
 
 const ENCODERS: Array<{ value: EncoderPreference; label: string; hint: string }> = [
   { value: 'auto', label: 'Auto', hint: 'GPU when ready' },
@@ -161,6 +182,28 @@ export default function SettingsModal(): React.JSX.Element {
               </button>
             ))}
           </div>
+        </div>
+
+        <div className="mt-5">
+          <label className="flex items-center gap-2 text-sm font-medium">
+            <Languages size={15} className="text-accent-400" />
+            Transcription language
+          </label>
+          <p className="mt-1 text-xs leading-relaxed text-zinc-500">
+            The spoken language Whisper transcribes. Leave on English (or pick yours) rather than
+            Auto-detect — auto sometimes mislabels the language (e.g. English as Welsh).
+          </p>
+          <select
+            value={settings?.transcriptionLanguage ?? 'en'}
+            onChange={(e) => void saveSettings({ transcriptionLanguage: e.target.value })}
+            className="mt-2.5 w-full rounded-xl border border-surface-600 bg-surface-850 px-3.5 py-2.5 text-sm text-zinc-200 focus:border-white/25 focus:outline-none"
+          >
+            {TRANSCRIPTION_LANGUAGES.map((l) => (
+              <option key={l.value} value={l.value}>
+                {l.label}
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="mt-5 border-t border-surface-700 pt-5">

--- a/src/shared/tighten.ts
+++ b/src/shared/tighten.ts
@@ -22,6 +22,19 @@ const POST_ROLL_SEC = 0.3
 /** Ignore removals shorter than this — not worth a visible jump cut. */
 const MIN_REMOVAL_SEC = 0.35
 const MIN_SEGMENT_SEC = 0.25
+/**
+ * Minimum length of a kept run between two cuts. A dense run of "um"s produces
+ * many short kept spans separated by tiny removals; cutting each one makes the
+ * clip jitter. When a kept run is shorter than this, we'd rather keep the
+ * small removed gap before it than add another jump cut.
+ */
+const MIN_KEPT_SEC = 1.2
+/**
+ * …but only bridge a short kept run back over a *small* gap. A genuinely long
+ * pause is still worth one clean cut even if the speech after it is short, so
+ * removals larger than this are never bridged away.
+ */
+const BRIDGE_MAX_GAP_SEC = 1.5
 
 const FILLER_WORDS = new Set(['um', 'uh', 'uhm', 'umm', 'erm', 'er', 'ah', 'mmm', 'hmm', 'mhm'])
 
@@ -57,7 +70,21 @@ export function computeKeptSegments(
     }
   }
 
-  const kept = merged.filter((s) => s.end - s.start >= MIN_SEGMENT_SEC)
+  // Anti-jitter: bridge short kept runs back over small removed gaps so dense
+  // filler ("word um word uh word") doesn't turn into a burst of jump cuts.
+  // Long pauses (gap > BRIDGE_MAX_GAP_SEC) are preserved as single clean cuts.
+  const spaced: KeptSegment[] = []
+  for (const seg of merged) {
+    const prev = spaced[spaced.length - 1]
+    const gapToPrev = prev ? seg.start - prev.end : Infinity
+    if (prev && seg.end - seg.start < MIN_KEPT_SEC && gapToPrev <= BRIDGE_MAX_GAP_SEC) {
+      prev.end = seg.end
+    } else {
+      spaced.push({ ...seg })
+    }
+  }
+
+  const kept = spaced.filter((s) => s.end - s.start >= MIN_SEGMENT_SEC)
   if (kept.length === 0) return null
 
   const keptDuration = kept.reduce((sum, s) => sum + (s.end - s.start), 0)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -278,6 +278,12 @@ export interface AppSettings {
    */
   keyStorageSecure: boolean
   transcriptionModel: string
+  /**
+   * Language for Whisper transcription: an ISO-639-1 code (e.g. 'en') that is
+   * sent to Whisper so it does not auto-detect and occasionally guess wrong
+   * (e.g. labelling English as Welsh). 'auto' lets Whisper detect per video.
+   */
+  transcriptionLanguage: string
   analysisModel: string
   encoder: EncoderPreference
   quality: QualityPreference
@@ -293,6 +299,7 @@ export interface AppSettings {
 export interface SettingsUpdate {
   apiKey?: string
   transcriptionModel?: string
+  transcriptionLanguage?: string
   analysisModel?: string
   encoder?: EncoderPreference
   quality?: QualityPreference

--- a/tests/speaker.test.ts
+++ b/tests/speaker.test.ts
@@ -110,15 +110,25 @@ describe('mouthActivity', () => {
   const W = 8
   const H = 8
   const flat = (v: number): Buffer => Buffer.alloc(W * H * 3, v)
+  const box = face(0.5, 0.9, 0.6)
 
   it('is zero for identical frames', () => {
-    expect(mouthActivity(flat(100), flat(100), face(0.5, 0.9, 0.6), W, H)).toBe(0)
+    expect(mouthActivity(flat(100), flat(100), box, W, H)).toBe(0)
   })
 
-  it('scales with pixel change in the mouth region', () => {
-    const a = flat(100)
-    const b = flat(140)
-    const activity = mouthActivity(a, b, face(0.5, 0.9, 0.6), W, H)
-    expect(activity).toBeCloseTo(40, 0)
+  it('ignores uniform whole-face motion (head bob / lighting)', () => {
+    // The mouth and upper face move together, so the differential cancels:
+    // a nodding or gesturing listener must not read as talking.
+    expect(mouthActivity(flat(100), flat(140), box, W, H)).toBe(0)
+  })
+
+  it('reports motion concentrated in the mouth region', () => {
+    // Only the lower (mouth) rows change; the upper face is still → speech.
+    const prev = flat(100)
+    const cur = Buffer.from(prev)
+    for (let y = 6; y < 8; y++) {
+      for (let x = 0; x < W * 3; x++) cur[y * W * 3 + x] = 140
+    }
+    expect(mouthActivity(prev, cur, box, W, H)).toBeCloseTo(40, 0)
   })
 })

--- a/tests/tighten.test.ts
+++ b/tests/tighten.test.ts
@@ -40,6 +40,50 @@ describe('computeKeptSegments', () => {
     const transcript = makeTranscript(['hi there'])
     expect(computeKeptSegments(transcript, 0, transcript.durationSec)).toBeNull()
   })
+
+  it('does not machine-gun cut dense filler', () => {
+    // A word every ~1.2s with an "um" between each. Cutting every filler would
+    // produce one jump cut per word (the reported jitter); the anti-jitter
+    // pass must collapse that to at most a couple of clean segments.
+    const words = []
+    const N = 8
+    for (let i = 0; i < N; i++) {
+      const base = i * 1.2
+      words.push({ text: 'word', start: base, end: base + 0.3 })
+      words.push({ text: 'um', start: base + 0.5, end: base + 0.9 })
+    }
+    const last = words[words.length - 1].end
+    const transcript = {
+      language: 'english',
+      durationSec: last,
+      segments: [{ id: 0, text: 'x', start: 0, end: last, words }]
+    }
+    const kept = computeKeptSegments(transcript, 0, last)
+    expect(kept === null || kept.length <= 2).toBe(true)
+  })
+
+  it('still cuts a genuine long pause amid filler', () => {
+    const words = []
+    // Stammer block, then a long silence, then a clean run of speech.
+    for (let i = 0; i < 3; i++) {
+      const b = i * 1.2
+      words.push({ text: 'word', start: b, end: b + 0.3 })
+      words.push({ text: 'um', start: b + 0.5, end: b + 0.9 })
+    }
+    for (let i = 0; i < 4; i++) {
+      const b = 6 + i * 0.4
+      words.push({ text: 'more', start: b, end: b + 0.3 })
+    }
+    const last = words[words.length - 1].end
+    const transcript = {
+      language: 'english',
+      durationSec: last,
+      segments: [{ id: 0, text: 'x', start: 0, end: last, words }]
+    }
+    const kept = computeKeptSegments(transcript, 0, last)
+    expect(kept).not.toBeNull()
+    expect(kept!.length).toBe(2)
+  })
 })
 
 describe('TimeMap', () => {


### PR DESCRIPTION
Fixes three issues reported by a user, plus a drag-drop guard.

## Speaker-aware reframing
Focuses the person actually talking and cuts between people cleanly instead of drifting:
- `mouthActivity` is now differential (mouth-region motion minus upper-face motion), so a nodding/gesturing listener or a moving head no longer reads as speech.
- `chooseFocusCentres` holds a new speaker for a cooldown before switching again (no ping-pong), and on a lost track re-acquires the face closest to the last speaker position rather than jumping to the biggest one.
- Focus keyframes are emitted at the segment median, so the crop lands on the face the shot settled on rather than an averaged in-between position.

## Transcription language
The language was never sent to Whisper, so it auto-detected per chunk and could guess wrong (e.g. English → Welsh). Added a `transcriptionLanguage` setting, threaded it into the Whisper request, and defaulted it to English, with Auto-detect and a language list available in Settings.

## Tighten-cut jitter
Dense filler ("word um word uh word") made a hard cut at nearly every word. A new anti-jitter pass bridges short kept runs back over small removed gaps, so heavy ums no longer machine-gun the clip. Genuine long pauses are still cut once, cleanly. Both export and live preview share this logic.

## Drag-drop guard
Disables the URL submit while an import is busy and shows the "Reading video…" state during a dropped-file import.

All changes verified: `npm run typecheck`, `npm run lint`, `npm test` (108 tests) and a production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NpcWHVsZoy48iXTCX4WWw

---
_Generated by [Claude Code](https://claude.ai/code/session_018NpcWHVsZoy48iXTCX4WWw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core transcription defaults, shared tighten-cut logic (export + preview), and speaker-tracking heuristics; behavior shifts are intentional but could surprise non-English users until they change Settings.
> 
> **Overview**
> Improves **auto-reframe** so the crop follows the active speaker more reliably: mouth motion is measured as mouth-minus-upper-face (so nods/gestures don’t look like speech), speaker switches get a short cooldown and re-acquire prefers the last position over the largest face, and focus keyframes use the **median** of each segment instead of the mean.
> 
> Adds **`transcriptionLanguage`** (default **English**, **Auto-detect** + language list in Settings), wired through settings → pipeline → Whisper’s `language` field so transcription isn’t left to per-chunk auto-detect.
> 
> **Tighten cuts** gains an anti-jitter pass that merges short kept spans across small gaps so dense filler doesn’t produce rapid jump cuts, while long pauses still split cleanly.
> 
> **Home import**: drag-drop sets the same busy state as file pick (shows “Reading video…”) and URL import is disabled while any import is in progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da24206a74156378b4056f5206d2bde2b70a85e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->