### PR TITLE
Fix navigation: non-destructive "New video" + confirm deletes

### DIFF
--- a/src/renderer/src/components/HomeScreen.tsx
+++ b/src/renderer/src/components/HomeScreen.tsx
@@ -317,10 +317,18 @@ function SetupPanel(): React.JSX.Element {
             preload="metadata"
           />
           <button
-            onClick={() => void goHomeClear(project.id)}
+            onClick={() => {
+              if (
+                window.confirm(
+                  `Delete "${project.name}"? This permanently removes the project and its ${project.clips.length} clip${project.clips.length === 1 ? '' : 's'}, and can't be undone.\n\nTo work on a different video without losing this one, use "New video" instead.`
+                )
+              ) {
+                void goHomeClear(project.id)
+              }
+            }}
             className="mt-3 flex items-center gap-1.5 text-xs text-zinc-500 transition hover:text-red-400"
           >
-            <Trash2 size={13} /> Remove and choose another video
+            <Trash2 size={13} /> Delete this project
           </button>
         </div>
 
@@ -466,7 +474,13 @@ function RecentProjects(): React.JSX.Element | null {
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  void deleteProject(p.id)
+                  if (
+                    window.confirm(
+                      `Delete "${p.name}"? This permanently removes the project and its ${p.clipCount} clip${p.clipCount === 1 ? '' : 's'}, and can't be undone.`
+                    )
+                  ) {
+                    void deleteProject(p.id)
+                  }
                 }}
                 className="rounded-lg p-1.5 text-zinc-600 opacity-0 transition hover:bg-surface-700 hover:text-red-400 group-hover:opacity-100"
               >

--- a/src/renderer/src/components/TopBar.tsx
+++ b/src/renderer/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { Clapperboard, Settings, ChevronLeft, ArrowUpCircle } from 'lucide-react'
+import { Clapperboard, Settings, ChevronLeft, ArrowUpCircle, Plus } from 'lucide-react'
 import { useStore } from '../store'
 
 export default function TopBar(): React.JSX.Element {
@@ -6,11 +6,15 @@ export default function TopBar(): React.JSX.Element {
   const project = useStore((s) => s.project)
   const goHome = useStore((s) => s.goHome)
   const closeEditor = useStore((s) => s.closeEditor)
+  const newProject = useStore((s) => s.newProject)
   const setSettingsOpen = useStore((s) => s.setSettingsOpen)
   const settings = useStore((s) => s.settings)
   const updateCheck = useStore((s) => s.updateCheck)
 
   const showBack = screen === 'clips' || screen === 'editor'
+  // A non-destructive way back to the import screen from anywhere a project is
+  // open (the old only route was deleting the current project).
+  const showNewVideo = project !== null && screen !== 'processing'
 
   return (
     <header className="app-topbar flex h-14 shrink-0 items-center gap-3 border-b border-white/[0.06] bg-surface-950/70 px-4 backdrop-blur-xl">
@@ -42,6 +46,16 @@ export default function TopBar(): React.JSX.Element {
       {!showBack && <div className="flex-1" />}
 
       <div className="flex items-center gap-2">
+        {showNewVideo && (
+          <button
+            onClick={newProject}
+            title="Start over with a different video — your current project stays saved in Recent projects"
+            className="flex items-center gap-1.5 rounded-lg border border-surface-600 px-3 py-1.5 text-xs font-medium text-zinc-300 transition hover:bg-surface-800 hover:text-zinc-100"
+          >
+            <Plus size={14} />
+            New video
+          </button>
+        )}
         {updateCheck?.updateAvailable && updateCheck.releaseUrl && (
           <button
             onClick={() => setSettingsOpen(true)}

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -77,6 +77,7 @@ interface AppState {
   deleteProject: (id: string) => Promise<void>
   relinkVideo: () => Promise<void>
   goHome: () => void
+  newProject: () => void
   setSettingsOpen: (open: boolean) => void
   saveSettings: (update: SettingsUpdate) => Promise<void>
   refreshSettings: () => Promise<void>
@@ -209,6 +210,11 @@ export const useStore = create<AppState>((set, get) => ({
   },
 
   goHome: () => set({ screen: 'home', selectedClipId: null, pipelineError: null }),
+
+  // Deselect the current project and return to the import screen so a new
+  // video can be added. Non-destructive: the project stays saved on disk and
+  // remains in "Recent projects".
+  newProject: () => set({ project: null, screen: 'home', selectedClipId: null, pipelineError: null }),
 
   setSettingsOpen: (open) => set({ settingsOpen: open }),
 


### PR DESCRIPTION
Once a project was open, the only way back to the import screen was "Remove and choose another video", which deleted the project and all its clips with no confirmation.

- **New video button** in the top bar, shown whenever a project is open (except during processing). It returns to the import screen without deleting anything — the project stays saved and listed under Recent projects. Reachable from the clips grid and the editor, so you no longer have to delete to start a new video.
- **Delete confirmation**: both the setup panel's delete action (reworded to "Delete this project") and the Recent projects trash button now confirm before removing, naming the project and its clip count.

Verified: `npm run typecheck`, `npm run lint`, `npm test` (108) and a production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NpcWHVsZoy48iXTCX4WWw

---
_Generated by [Claude Code](https://claude.ai/code/session_018NpcWHVsZoy48iXTCX4WWw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only navigation and confirmation UX; no IPC or persistence logic changes beyond existing `deleteProject`.
> 
> **Overview**
> Adds a **New video** control in the top bar whenever a project is loaded (hidden during processing). It calls a new `newProject` store action that clears the in-memory selection and returns to the import screen **without** deleting anything on disk, so users can start another video while the current project stays in Recent projects.
> 
> Destructive paths are tightened: the setup panel action is relabeled **Delete this project** and both that control and the Recent projects trash icon now use `window.confirm` with the project name and clip count; the setup copy also points users to **New video** instead of deleting by mistake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec85a34dbf29b035f13f24737ba2980843e2a620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->