### PR TITLE
Fix spawn EINVAL on Windows during source updates

### DIFF
--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -242,13 +242,35 @@ export function installUpdate(): void {
   configureAutoUpdater().quitAndInstall()
 }
 
+/**
+ * Node 20+ on Windows rejects spawning `.cmd`/`.bat` without `shell: true`
+ * (CVE-2024-27980). Exported for tests.
+ */
+export function spawnStepOptions(
+  cmd: string,
+  cwd: string
+): { cwd: string; windowsHide: boolean; shell?: boolean; env: NodeJS.ProcessEnv } {
+  const shell =
+    process.platform === 'win32' &&
+    (cmd === 'npm' || cmd === 'npm.cmd' || /\.(cmd|bat)$/i.test(cmd))
+  return {
+    cwd,
+    windowsHide: true,
+    env: process.env,
+    ...(shell ? { shell: true } : {})
+  }
+}
+
 function runStep(
   cmd: string,
   args: string[],
   cwd: string
 ): Promise<string> {
+  if (!existsSync(cwd)) {
+    return Promise.reject(new Error(`Checkout folder not found: ${cwd}`))
+  }
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { cwd, windowsHide: true })
+    const child = spawn(cmd, args, spawnStepOptions(cmd, cwd))
     let stdout = ''
     let stderr = ''
     child.stdout.on('data', (d: Buffer) => {
@@ -258,7 +280,13 @@ function runStep(
       stderr += d.toString()
       if (stderr.length > 65536) stderr = stderr.slice(-32768)
     })
-    child.on('error', reject)
+    child.on('error', (err) => {
+      reject(
+        new Error(
+          `Could not run ${cmd}: ${err instanceof Error ? err.message : String(err)}`
+        )
+      )
+    })
     child.on('close', (code) => {
       if (code === 0) return resolve(stdout)
       const detail = stderr.split('\n').filter(Boolean).slice(-3).join(' ').trim()
@@ -267,7 +295,7 @@ function runStep(
   })
 }
 
-const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const npmCmd = 'npm'
 let sourceUpdateRunning = false
 
 /**

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -1,7 +1,13 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { compareVersions, evaluateUpdate, findGitRoot, resolveSourceRepoRoot } from '../src/main/updates'
+import {
+  compareVersions,
+  evaluateUpdate,
+  findGitRoot,
+  resolveSourceRepoRoot,
+  spawnStepOptions
+} from '../src/main/updates'
 
 describe('findGitRoot', () => {
   it('walks up from a nested directory to the repo root', () => {
@@ -38,6 +44,21 @@ describe('compareVersions', () => {
   it('treats missing segments as zero', () => {
     expect(compareVersions('1.2', '1.2.0')).toBe(0)
     expect(compareVersions('1.2.1', '1.2')).toBeGreaterThan(0)
+  })
+})
+
+describe('spawnStepOptions', () => {
+  it('enables shell for npm on Windows (CVE-2024-27980)', () => {
+    if (process.platform !== 'win32') return
+    expect(spawnStepOptions('npm', process.cwd()).shell).toBe(true)
+    expect(spawnStepOptions('npm.cmd', process.cwd()).shell).toBe(true)
+    expect(spawnStepOptions('git', process.cwd()).shell).toBeUndefined()
+  })
+
+  it('does not force shell on Unix', () => {
+    if (process.platform === 'win32') return
+    expect(spawnStepOptions('npm', process.cwd()).shell).toBeUndefined()
+    expect(spawnStepOptions('git', process.cwd()).shell).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users running ClipForge from a **git checkout** (not a packaged AppImage/NSIS build) who click **Update to v… and restart** can hit a bare `spawn EINVAL` error on Windows with Node 20+.

This happens because the source-update path runs `npm install` and `npm run build` via `child_process.spawn`. On Windows we previously spawned `npm.cmd` without `{ shell: true }`, which Node rejects after the CVE-2024-27980 security fix.

## Fix

- Spawn `npm` with `shell: true` on Windows (and keep plain `spawn` for `git` and Unix).
- Validate the checkout `cwd` exists before spawning.
- Improve spawn error messages so failures name the command instead of only `spawn EINVAL`.

## How to verify

On Windows, from a git checkout on v0.5.4 (or any version behind latest):

1. Open **Settings → App updates**
2. Click **Update to v… and restart** (or **Retry** after a failed attempt)
3. The update should progress through pull / install / build instead of failing immediately with `spawn EINVAL`

## Notes

Packaged installs (AppImage, NSIS) use electron-updater download + restart and are unaffected by this path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2c290c1-d9c3-4971-9a25-96595e5942d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2c290c1-d9c3-4971-9a25-96595e5942d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

