### PR TITLE
Enforce sentence boundaries at clip endings

### DIFF
--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -6,6 +6,7 @@ import type {
   Transcript
 } from '@shared/types'
 import { DEFAULT_CAPTION_STYLE_ID } from '@shared/captionStyles'
+import { normalizeClipEnd, sentenceEndTimes } from '@shared/sentences'
 import { chatJSON } from './openai'
 
 interface RawHighlight {
@@ -195,9 +196,18 @@ const MAX_END_TRIM_SEC = 20
 /** How much transcript beyond a clip's end the ending review gets to see. */
 const CONTINUATION_SEC = 45
 
+function withNormalizedEnd(clip: Clip, transcript: Transcript, videoDurationSec: number): Clip {
+  const end = normalizeClipEnd(clip.suggestedStart, clip.suggestedEnd, transcript, videoDurationSec, {
+    postRollSec: END_POST_ROLL_SEC,
+    maxExtendSec: MAX_END_EXTEND_SEC
+  })
+  if (end === clip.suggestedEnd) return clip
+  return { ...clip, suggestedEnd: end, edit: { ...clip.edit, end } }
+}
+
 const REFINE_SYSTEM_PROMPT = `You quality-check the ENDINGS of short vertical clips cut from a longer video. A good clip has the shape of a complete micro-video — hook, build, and an ending that lands. What "lands" depends on the material: a story lands on its resolution or emotional beat, comedy on the punchline, an argument on its sharpest formulation, a reveal on the answer, practical content on the takeaway, and a provocative clip can land on a pointed question that throws back to the hook. An ending fails when the clip stops on setup, scene-setting context, the middle of a list, or a plain observation that promises more (e.g. ending on "People were experimenting with ChatGPT for the first time" — that sentence exists to set up whatever comes next).
 
-For each clip you receive its transcript and the sentences that follow it in the source video, each tagged with the time it ends. Judge the current ending strictly. When it fails, pick the tagged sentence end-time where the thought completes — usually extending slightly to include the beat that follows, occasionally trimming back to an earlier, stronger closer. Only use end times that appear in the tags.`
+For each clip you receive its transcript and the sentences that follow it in the source video, each tagged with the time it ends. Judge the current ending strictly. A clip whose last spoken word lacks terminal punctuation (. ! ?) has not finished its sentence and must be extended. When an ending fails, pick the tagged sentence end-time where the thought completes — usually extending slightly to include the beat that follows, occasionally trimming back to an earlier, stronger closer. Only use end times that appear in the tags.`
 
 interface RefinedEnding {
   index: number
@@ -244,11 +254,11 @@ const REFINE_SCHEMA = {
 export function applyRefinedEnding(
   clip: Clip,
   betterEnd: number,
-  segmentEnds: number[],
+  sentenceEnds: number[],
   videoDurationSec: number
 ): Clip {
   if (!Number.isFinite(betterEnd)) return clip
-  const snapped = snap(betterEnd, segmentEnds, SENTENCE_SNAP_SEC)
+  const snapped = snap(betterEnd, sentenceEnds, SENTENCE_SNAP_SEC)
   const newEnd = Math.min(videoDurationSec, snapped + END_POST_ROLL_SEC)
   const current = clip.suggestedEnd
   if (
@@ -278,7 +288,7 @@ async function refineClipEndings(
   signal?: AbortSignal
 ): Promise<Clip[]> {
   if (clips.length === 0) return clips
-  const segmentEnds = transcript.segments.map((s) => s.end).sort((a, b) => a - b)
+  const sentenceEnds = sentenceEndTimes(transcript)
 
   const blocks = clips.map((clip, i) => {
     const inClip = transcript.segments.filter(
@@ -326,7 +336,7 @@ async function refineClipEndings(
     for (const entry of res.endings ?? []) {
       const clip = refined[entry.index]
       if (!clip || entry.ends_with_payoff) continue
-      refined[entry.index] = applyRefinedEnding(clip, entry.better_end, segmentEnds, videoDurationSec)
+      refined[entry.index] = applyRefinedEnding(clip, entry.better_end, sentenceEnds, videoDurationSec)
       if (process.env.CLIPFORGE_DEBUG && refined[entry.index] !== clip) {
         console.error(
           `[highlights] ending review moved clip ${entry.index} end ` +
@@ -334,12 +344,12 @@ async function refineClipEndings(
         )
       }
     }
-    return refined
+    return refined.map((c) => withNormalizedEnd(c, transcript, videoDurationSec))
   } catch (err) {
     if (signal?.aborted) throw err
     // The candidates are still usable without the ending review.
     console.error('Clip ending review failed; keeping original endings:', err)
-    return clips
+    return clips.map((c) => withNormalizedEnd(c, transcript, videoDurationSec))
   }
 }
 
@@ -444,8 +454,13 @@ async function requestHighlights(
       wordEnds.push(w.end)
     }
   }
-  const segmentEnds = transcript.segments.map((s) => s.end).sort((a, b) => a - b)
+  const sentenceEnds = sentenceEndTimes(transcript)
   const minDur = minDurationFor(options.clipLength)
+  const normalizeEnd = (start: number, end: number): number =>
+    normalizeClipEnd(start, end, transcript, videoDurationSec, {
+      postRollSec: END_POST_ROLL_SEC,
+      maxExtendSec: MAX_END_EXTEND_SEC
+    })
 
   if (process.env.CLIPFORGE_DEBUG) {
     console.error('[highlights] raw LLM response:', JSON.stringify(res, null, 2))
@@ -457,20 +472,21 @@ async function requestHighlights(
     let end = Math.max(start + 1, Math.min(raw.end, videoDurationSec))
     // Snap the start to a word boundary for a clean cut, with a little pre-roll.
     start = Math.max(0, snap(start, wordStarts, 1.5) - START_PRE_ROLL_SEC)
-    // Ends feel natural when they land on a sentence boundary; only fall back
-    // to the nearest word end when no sentence finishes nearby.
-    const sentenceEnd = snap(end, segmentEnds, SENTENCE_SNAP_SEC)
-    end = Math.min(
-      videoDurationSec,
-      (sentenceEnd !== end ? sentenceEnd : snap(end, wordEnds, 1.5)) + END_POST_ROLL_SEC
-    )
+    // Rough word snap, then extend to the next punctuated sentence end when the
+    // model (or Whisper segment boundary) stopped mid-thought.
+    end = Math.min(videoDurationSec, snap(end, wordEnds, 1.5) + END_POST_ROLL_SEC)
+    end = normalizeEnd(start, end)
     // Models often under-shoot durations: extend short clips to the next
     // sentence boundary that satisfies the length preference — or to the end
     // of the video when no sentence boundary is late enough.
     if (end - start < minDur) {
       const targetEnd = start + minDur
-      const nextSentenceEnd = segmentEnds.find((e) => e >= targetEnd)
-      end = Math.min(videoDurationSec, (nextSentenceEnd ?? targetEnd) + END_POST_ROLL_SEC)
+      const nextSentenceEnd = sentenceEnds.find((e) => e + END_POST_ROLL_SEC >= targetEnd)
+      const extended =
+        nextSentenceEnd !== undefined
+          ? Math.min(videoDurationSec, nextSentenceEnd + END_POST_ROLL_SEC)
+          : Math.min(videoDurationSec, targetEnd + END_POST_ROLL_SEC)
+      end = normalizeEnd(start, extended)
     }
     if (end - start < Math.min(MIN_CLIP_SEC, videoDurationSec * 0.5)) {
       if (process.env.CLIPFORGE_DEBUG) {

--- a/src/shared/sentences.ts
+++ b/src/shared/sentences.ts
@@ -1,0 +1,74 @@
+import type { Transcript, TranscriptWord } from './types'
+import { wordsInRange } from './captionLayout'
+
+/** True when spoken text ends a sentence (terminal punctuation). */
+export function endsSentence(text: string): boolean {
+  return /[.!?]["']?$/.test(text.trim())
+}
+
+/**
+ * Timestamps where a sentence finishes, derived from word punctuation rather
+ * than Whisper segment boundaries (segments often break mid-sentence).
+ */
+export function sentenceEndTimes(transcript: Transcript): number[] {
+  const ends: number[] = []
+  for (const seg of transcript.segments) {
+    for (const w of seg.words) {
+      if (endsSentence(w.text)) ends.push(w.end)
+    }
+    // Whisper sometimes omits terminal punctuation on the last word but keeps
+    // it on the segment text.
+    const last = seg.words[seg.words.length - 1]
+    if (last && !endsSentence(last.text) && endsSentence(seg.text)) {
+      ends.push(last.end)
+    }
+  }
+  return [...new Set(ends)].sort((a, b) => a - b)
+}
+
+export interface NormalizeClipEndOptions {
+  postRollSec?: number
+  /** How far the end may move forward to reach a sentence boundary. */
+  maxExtendSec?: number
+}
+
+/**
+ * Move a clip end forward when needed so the last spoken word completes a
+ * sentence. Returns the input end unchanged when already on a sentence end or
+ * when no punctuated end exists within the extension cap.
+ */
+export function normalizeClipEnd(
+  clipStart: number,
+  clipEnd: number,
+  transcript: Transcript,
+  videoDurationSec: number,
+  opts: NormalizeClipEndOptions = {}
+): number {
+  const postRollSec = opts.postRollSec ?? 0.6
+  const maxExtendSec = opts.maxExtendSec ?? 45
+  const words = wordsInRange(transcript, clipStart, clipEnd)
+  if (words.length === 0) return clipEnd
+
+  const lastWord = words[words.length - 1]
+  if (endsSentence(lastWord.text)) {
+    const snapped = Math.min(videoDurationSec, lastWord.end + postRollSec)
+    return snapped >= clipStart + 1 ? snapped : clipEnd
+  }
+
+  const sentenceEnds = sentenceEndTimes(transcript)
+  const next = sentenceEnds.find((t) => t >= lastWord.end - 0.05)
+  if (!next || next - clipEnd > maxExtendSec) return clipEnd
+
+  const normalized = Math.min(videoDurationSec, next + postRollSec)
+  return normalized >= clipStart + 1 ? normalized : clipEnd
+}
+
+/** Last spoken word whose midpoint falls inside [clipStart, clipEnd]. */
+export function lastWordInClip(
+  transcript: Transcript,
+  clipStart: number,
+  clipEnd: number
+): TranscriptWord | null {
+  const words = wordsInRange(transcript, clipStart, clipEnd)
+  return words.length > 0 ? words[words.length - 1] : null
+}

--- a/tests/highlights.test.ts
+++ b/tests/highlights.test.ts
@@ -70,11 +70,11 @@ describe('targetClipCount', () => {
 })
 
 describe('applyRefinedEnding', () => {
-  const segmentEnds = [10, 20, 30, 38.5, 47, 60]
+  const sentenceEnds = [10, 20, 30, 38.5, 47, 60]
   const VIDEO_DUR = 300
 
   it('extends the clip to the sentence that carries the payoff', () => {
-    const c = applyRefinedEnding(clip('a', 5, 30.6, 90), 38.4, segmentEnds, VIDEO_DUR)
+    const c = applyRefinedEnding(clip('a', 5, 30.6, 90), 38.4, sentenceEnds, VIDEO_DUR)
     // Snapped to the 38.5s sentence end plus the 0.6s post-roll.
     expect(c.suggestedEnd).toBeCloseTo(39.1, 3)
     expect(c.edit.end).toBeCloseTo(39.1, 3)
@@ -82,24 +82,24 @@ describe('applyRefinedEnding', () => {
   })
 
   it('can trim back to an earlier, stronger closer', () => {
-    const c = applyRefinedEnding(clip('a', 5, 47.6, 90), 38.5, segmentEnds, VIDEO_DUR)
+    const c = applyRefinedEnding(clip('a', 5, 47.6, 90), 38.5, sentenceEnds, VIDEO_DUR)
     expect(c.suggestedEnd).toBeCloseTo(39.1, 3)
   })
 
   it('ignores no-op and implausible suggestions', () => {
     const original = clip('a', 5, 30.6, 90)
     // Same ending re-suggested: below the 1s change threshold.
-    expect(applyRefinedEnding(original, 30, segmentEnds, VIDEO_DUR)).toBe(original)
+    expect(applyRefinedEnding(original, 30, sentenceEnds, VIDEO_DUR)).toBe(original)
     // Extension beyond the 45s cap.
     expect(applyRefinedEnding(clip('a', 5, 30.6, 90), 200, [200], VIDEO_DUR)).toEqual(
       clip('a', 5, 30.6, 90)
     )
     // Trim that would leave the clip shorter than the minimum.
-    expect(applyRefinedEnding(clip('a', 5, 20.6, 90), 10, segmentEnds, VIDEO_DUR)).toEqual(
+    expect(applyRefinedEnding(clip('a', 5, 20.6, 90), 10, sentenceEnds, VIDEO_DUR)).toEqual(
       clip('a', 5, 20.6, 90)
     )
     // Nonsense values.
-    expect(applyRefinedEnding(original, Number.NaN, segmentEnds, VIDEO_DUR)).toBe(original)
+    expect(applyRefinedEnding(original, Number.NaN, sentenceEnds, VIDEO_DUR)).toBe(original)
   })
 
   it('clamps to the end of the video', () => {

--- a/tests/sentences.test.ts
+++ b/tests/sentences.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import type { Transcript } from '@shared/types'
+import {
+  endsSentence,
+  lastWordInClip,
+  normalizeClipEnd,
+  sentenceEndTimes
+} from '../src/shared/sentences'
+
+/** Whisper often breaks before the thought completes — e.g. segment ends on "so". */
+function transcriptEndingOnSo(): Transcript {
+  return {
+    language: 'english',
+    durationSec: 20,
+    segments: [
+      {
+        id: 0,
+        text: 'and that is why it matters so',
+        start: 0,
+        end: 3.4,
+        words: [
+          { text: 'and', start: 0, end: 0.3 },
+          { text: 'that', start: 0.4, end: 0.7 },
+          { text: 'is', start: 0.8, end: 1.1 },
+          { text: 'why', start: 1.2, end: 1.5 },
+          { text: 'it', start: 1.6, end: 1.9 },
+          { text: 'matters', start: 2.0, end: 2.3 },
+          { text: 'so', start: 2.4, end: 2.7 }
+        ]
+      },
+      {
+        id: 1,
+        text: 'much for everyone today.',
+        start: 3.0,
+        end: 6.4,
+        words: [
+          { text: 'much', start: 3.0, end: 3.3 },
+          { text: 'for', start: 3.4, end: 3.7 },
+          { text: 'everyone', start: 3.8, end: 4.1 },
+          { text: 'today.', start: 4.2, end: 4.5 }
+        ]
+      }
+    ]
+  }
+}
+
+describe('endsSentence', () => {
+  it('detects terminal punctuation', () => {
+    expect(endsSentence('today.')).toBe(true)
+    expect(endsSentence('really?')).toBe(true)
+    expect(endsSentence('wow!')).toBe(true)
+    expect(endsSentence('so')).toBe(false)
+  })
+})
+
+describe('sentenceEndTimes', () => {
+  it('uses word punctuation, not Whisper segment ends', () => {
+    const ends = sentenceEndTimes(transcriptEndingOnSo())
+    expect(ends).toEqual([4.5])
+  })
+})
+
+describe('normalizeClipEnd', () => {
+  const transcript = transcriptEndingOnSo()
+  const postRollSec = 0.6
+
+  it('extends past a segment boundary that ends on "so"', () => {
+    // Segment 0 ends at 2.7s on the word "so"; the real sentence ends at 4.5s.
+    const end = normalizeClipEnd(0, 3.3, transcript, 20, { postRollSec })
+    expect(end).toBeCloseTo(4.5 + postRollSec, 5)
+  })
+
+  it('leaves a clip that already ends on a sentence', () => {
+    const end = normalizeClipEnd(0, 5.1, transcript, 20, { postRollSec })
+    expect(end).toBeCloseTo(5.1, 5)
+    expect(lastWordInClip(transcript, 0, end)?.text).toBe('today.')
+  })
+
+  it('does not extend beyond the cap', () => {
+    const end = normalizeClipEnd(0, 3.3, transcript, 20, { postRollSec, maxExtendSec: 0.5 })
+    expect(end).toBe(3.3)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clips could end mid-sentence on connective words like **"so"** because clip boundaries were snapped to **Whisper segment ends**, which often break before a thought is complete.

## Fix

- Add `src/shared/sentences.ts` to detect real sentence ends from **word punctuation** (`.`, `!`, `?`), with a segment-text fallback when Whisper omits it on the last word.
- After both highlight-selection passes, **extend clip tails forward** to the next punctuated sentence end (up to 45s) instead of trusting segment boundaries.
- Tighten the ending-review prompt: a clip whose last word lacks terminal punctuation has not finished its sentence.

## Example

Segment ends at `"so"` → clip now extends through `"much for everyone today."` before the tail padding.

## Tests

- `tests/sentences.test.ts` — regression for the `"so"` / segment-split case
- Existing `applyRefinedEnding` tests updated to use sentence-end times
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2c290c1-d9c3-4971-9a25-96595e5942d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2c290c1-d9c3-4971-9a25-96595e5942d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

