### PR TITLE
Fix camera shake when auto framing follows a moving speaker

### DIFF
--- a/src/main/pipeline/faces.ts
+++ b/src/main/pipeline/faces.ts
@@ -12,9 +12,10 @@ import { chooseFocusCentres, iou, mouthActivity, type FaceBox } from './speaker'
 /**
  * Face-based auto reframing. Samples clip frames with ffmpeg, detects faces
  * with UltraFace RFB-320 (ONNX, CPU), infers the active speaker from mouth
- * movement (see speaker.ts) and builds a piecewise-constant focus track:
- * stable segments with hard cuts between speaker positions, the way social
- * clipping tools reframe multi-speaker footage.
+ * movement (see speaker.ts) and builds a focus track of stable segments:
+ * hard cuts between speaker positions at camera cuts and speaker switches
+ * (the way social clipping tools reframe multi-speaker footage), smooth pans
+ * when the same person moves within a shot (see shared/focusTrack.ts).
  */
 
 const MODEL_W = 320
@@ -227,7 +228,11 @@ function trackRun(
     const median = sorted[Math.floor(sorted.length / 2)]
     out.push({
       t: clipStartSec + (runStartFrame + fromFrame) / SAMPLE_FPS,
-      x: Math.min(1, Math.max(0, median))
+      x: Math.min(1, Math.max(0, median)),
+      // A run starts at a camera cut or speaker switch — the crop snaps
+      // there. Later keyframes in the run are the same person moving within
+      // the shot, which the samplers follow with a smooth pan (focusTrack.ts).
+      cut: fromFrame === 0
     })
   }
 

--- a/src/main/pipeline/render.ts
+++ b/src/main/pipeline/render.ts
@@ -6,6 +6,7 @@ import type {
   AspectRatio,
   BrandingSettings,
   Clip,
+  FocusKeyframe,
   QualityPreference,
   Transcript,
   VideoInfo,
@@ -13,6 +14,7 @@ import type {
 } from '@shared/types'
 import type { EncoderPreference } from '@shared/types'
 import { computeKeptSegments, remapTranscript, TimeMap, type KeptSegment } from '@shared/tighten'
+import { focusPanDuration, focusSnaps } from '@shared/focusTrack'
 import { computeZoomEvents, remapZoomEvents, type ZoomEvent } from '@shared/zoom'
 import { runFfmpegWith } from './ffmpeg'
 import { buildAss, fontsDir } from './captions'
@@ -62,8 +64,11 @@ function escapeFilterPath(p: string): string {
 
 /**
  * Build the crop x-position expression. Manual framing is a constant focus;
- * auto framing becomes a piecewise-constant expression over t (clip-relative)
- * so the crop hard-cuts between speaker positions like a camera switch.
+ * auto framing becomes a piecewise expression over t (clip-relative) that
+ * mirrors focusAt: hard snaps at camera cuts / speaker switches, short eased
+ * pans for within-shot moves of the same person. (Hard-stepping the crop on
+ * every refocus of a moving speaker read as camera shake, magnified further
+ * whenever the auto zoom was pushed in.)
  */
 function focusExpression(clip: Clip): string {
   const track = clip.focusTrack
@@ -71,13 +76,26 @@ function focusExpression(clip: Clip): string {
     return Math.max(0, Math.min(1, clip.edit.focusX)).toFixed(4)
   }
   // Keyframes are in source time; renders seek with -ss so t starts at 0.
-  const steps = track
-    .map((kf) => ({ t: kf.t - clip.edit.start, x: Math.max(0, Math.min(1, kf.x)) }))
-    .filter((kf, i) => i === 0 || kf.t > 0)
-  if (steps.length === 0) return '0.5'
-  let expr = steps[steps.length - 1].x.toFixed(4)
+  const steps: FocusKeyframe[] = track.map((kf) => ({
+    ...kf,
+    t: kf.t - clip.edit.start,
+    x: Math.max(0, Math.min(1, kf.x))
+  }))
+  // Collapse keyframes at/before the clip start into a single base value.
+  while (steps.length > 1 && steps[1].t <= 0) steps.shift()
+
+  const value = (i: number): string => {
+    const kf = steps[i]
+    if (i === 0 || focusSnaps(steps, i)) return kf.x.toFixed(4)
+    // Smoothstep pan p*p*(3-2p) over the pan window, same curve as focusAt.
+    const prev = steps[i - 1].x
+    const dur = focusPanDuration(steps, i)
+    const p = `min(1,max(0,(t-${kf.t.toFixed(3)})/${dur.toFixed(3)}))`
+    return `(${prev.toFixed(4)}+${(kf.x - prev).toFixed(4)}*${p}*${p}*(3-2*${p}))`
+  }
+  let expr = value(steps.length - 1)
   for (let i = steps.length - 2; i >= 0; i--) {
-    expr = `if(lt(t,${Math.max(0, steps[i + 1].t).toFixed(3)}),${steps[i].x.toFixed(4)},${expr})`
+    expr = `if(lt(t,${Math.max(0, steps[i + 1].t).toFixed(3)}),${value(i)},${expr})`
   }
   return expr
 }

--- a/src/renderer/src/components/EditorScreen.tsx
+++ b/src/renderer/src/components/EditorScreen.tsx
@@ -228,8 +228,8 @@ export default function EditorScreen(): React.JSX.Element {
                   {clip.edit.framing === 'auto' && clip.focusTrack ? (
                     <p className="mt-2 text-[11px] leading-relaxed text-zinc-500">
                       Following {clip.focusTrack.length} tracked speaker position
-                      {clip.focusTrack.length === 1 ? '' : 's'} — the crop cuts automatically when
-                      the speaker moves.
+                      {clip.focusTrack.length === 1 ? '' : 's'} — the crop pans smoothly as the
+                      speaker moves and cuts on camera or speaker changes.
                     </p>
                   ) : (
                     <div className="mt-3">

--- a/src/shared/focusTrack.ts
+++ b/src/shared/focusTrack.ts
@@ -1,11 +1,62 @@
 import type { FocusKeyframe } from './types'
 
-/** Sample a piecewise-constant focus track at a given source time. */
+/**
+ * Focus-track sampling shared by the live preview (object-position) and the
+ * export (ffmpeg crop expression, see render.ts), so both move identically.
+ *
+ * Keyframes that land on a camera cut or speaker switch (kf.cut) snap
+ * instantly — a hard reframe reads as a deliberate camera change there. But
+ * keyframes produced by the *same person moving within a shot* must not snap:
+ * a talking head that sways or drifts emits a refocus every few seconds, and
+ * hard-stepping the crop on each one reads as constant camera shake —
+ * especially with auto zoom pushed in, which magnifies every jump. Those
+ * small shifts are followed with a short eased pan instead.
+ */
+
+/** Duration of the eased pan used for within-shot focus moves. */
+export const FOCUS_PAN_SEC = 0.6
+/**
+ * Shifts larger than this (normalized frame width) snap even without a cut
+ * flag: a jump that big is a speaker switch, and legacy tracks saved before
+ * cut flags existed must keep their hard switches.
+ */
+export const FOCUS_PAN_MAX_SHIFT = 0.3
+
+/** Smoothstep ease: gentle attack and landing, the classic camera-pan curve. */
+export function focusEase(p: number): number {
+  const c = Math.min(1, Math.max(0, p))
+  return c * c * (3 - 2 * c)
+}
+
+/** Pan duration for the keyframe at `index`, capped so it never overruns the next keyframe. */
+export function focusPanDuration(track: FocusKeyframe[], index: number): number {
+  const next = track[index + 1]
+  return next ? Math.min(FOCUS_PAN_SEC, Math.max(0, next.t - track[index].t)) : FOCUS_PAN_SEC
+}
+
+/** Whether the crop snaps to the keyframe at `index` instead of panning to it. */
+export function focusSnaps(track: FocusKeyframe[], index: number): boolean {
+  const kf = track[index]
+  const prev = track[index - 1]
+  if (!prev) return true
+  return (
+    kf.cut === true ||
+    Math.abs(kf.x - prev.x) > FOCUS_PAN_MAX_SHIFT ||
+    focusPanDuration(track, index) < 0.05
+  )
+}
+
+/** Sample the focus track at a given source time. */
 export function focusAt(track: FocusKeyframe[], t: number): number {
-  let x = track[0]?.x ?? 0.5
-  for (const kf of track) {
-    if (kf.t <= t) x = kf.x
+  let index = -1
+  for (let i = 0; i < track.length; i++) {
+    if (track[i].t <= t) index = i
     else break
   }
-  return x
+  if (index <= 0) return track[0]?.x ?? 0.5
+  const kf = track[index]
+  if (focusSnaps(track, index)) return kf.x
+  const prev = track[index - 1]
+  const p = focusEase((t - kf.t) / focusPanDuration(track, index))
+  return prev.x + (kf.x - prev.x) * p
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,11 +41,17 @@ export type ReframeMode = 'crop' | 'fit-blur'
 /** Auto = follow the AI face track; manual = fixed focusX slider. */
 export type FramingMode = 'auto' | 'manual'
 
-/** One step of the piecewise-constant focus track (t in source seconds). */
+/** One step of the focus track (t in source seconds). */
 export interface FocusKeyframe {
   t: number
   /** Horizontal face centre, 0 = far left, 1 = far right. */
   x: number
+  /**
+   * True when this keyframe lands on a camera cut or speaker switch, where
+   * the crop must snap instantly. Absent/false keyframes are within-shot
+   * moves of the same person, which the crop reaches with a smooth pan.
+   */
+  cut?: boolean
 }
 
 export interface ClipEditState {

--- a/tests/focusTrack.test.ts
+++ b/tests/focusTrack.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { focusAt } from '@shared/focusTrack'
+import { FOCUS_PAN_SEC, focusAt } from '@shared/focusTrack'
 import { buildFocusTrack } from '../src/main/pipeline/faces'
 
 describe('focusAt', () => {
@@ -8,12 +8,47 @@ describe('focusAt', () => {
     { t: 14, x: 0.8 }
   ]
 
-  it('returns the last keyframe at or before t (piecewise constant)', () => {
+  it('snaps instantly on large shifts (speaker switches)', () => {
     expect(focusAt(track, 9)).toBe(0.2) // before the first keyframe
     expect(focusAt(track, 10)).toBe(0.2)
     expect(focusAt(track, 13.9)).toBe(0.2)
     expect(focusAt(track, 14)).toBe(0.8)
     expect(focusAt(track, 99)).toBe(0.8)
+  })
+
+  it('pans smoothly to small within-shot shifts instead of stepping', () => {
+    const moving = [
+      { t: 10, x: 0.5, cut: true },
+      { t: 14, x: 0.62 }
+    ]
+    // Starts at the old position, eases towards the new one, settles there.
+    expect(focusAt(moving, 14)).toBeCloseTo(0.5)
+    const mid = focusAt(moving, 14 + FOCUS_PAN_SEC / 2)
+    expect(mid).toBeGreaterThan(0.5)
+    expect(mid).toBeLessThan(0.62)
+    expect(focusAt(moving, 14 + FOCUS_PAN_SEC)).toBeCloseTo(0.62)
+    expect(focusAt(moving, 99)).toBeCloseTo(0.62)
+  })
+
+  it('snaps on keyframes flagged as cuts even for small shifts', () => {
+    const cutTrack = [
+      { t: 10, x: 0.5, cut: true },
+      { t: 14, x: 0.62, cut: true }
+    ]
+    expect(focusAt(cutTrack, 14)).toBe(0.62)
+    expect(focusAt(cutTrack, 14.1)).toBe(0.62)
+  })
+
+  it('completes a pan before the next keyframe takes over', () => {
+    const dense = [
+      { t: 10, x: 0.5, cut: true },
+      { t: 14, x: 0.6 },
+      { t: 14.3, x: 0.7 }
+    ]
+    // The 14s pan is capped at 0.3s, so 14.3 starts exactly from 0.6.
+    expect(focusAt(dense, 14.299)).toBeCloseTo(0.6, 2)
+    expect(focusAt(dense, 14.3)).toBeCloseTo(0.6)
+    expect(focusAt(dense, 14.3 + FOCUS_PAN_SEC)).toBeCloseTo(0.7)
   })
 
   it('defaults to centre for an empty track', () => {
@@ -58,5 +93,19 @@ describe('buildFocusTrack', () => {
     expect(track!.length).toBe(2)
     // The cut refocuses exactly at the shot change (frame 8 at 2 fps = 4s).
     expect(track![1].t).toBe(4)
+  })
+
+  it('flags run-start keyframes as cuts and within-shot moves as pans', () => {
+    const centres = [
+      ...Array.from({ length: 8 }, () => 0.3),
+      ...Array.from({ length: 8 }, () => 0.45), // same shot, person moved
+      ...Array.from({ length: 8 }, () => 0.8) // camera cut
+    ]
+    const track = buildFocusTrack(centres, 0, [16])
+    expect(track).not.toBeNull()
+    expect(track!.length).toBe(3)
+    expect(track![0].cut).toBe(true) // clip start
+    expect(track![1].cut).toBe(false) // person moved within the shot
+    expect(track![2].cut).toBe(true) // camera cut
   })
 })

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -98,6 +98,22 @@ describe('buildFilterGraph', () => {
     expect(noImage.filterComplex).not.toContain('colorchannelmixer')
   })
 
+  it('pans the crop for within-shot focus moves and snaps at cuts', () => {
+    const clip = makeClip()
+    clip.edit.framing = 'auto'
+    clip.focusTrack = [
+      { t: 0, x: 0.5, cut: true },
+      { t: 5, x: 0.62 }, // small within-shot move -> eased pan
+      { t: 12, x: 0.2, cut: true } // speaker switch -> hard snap
+    ]
+    const graph = buildFilterGraph(clip, source, null, 30, null)
+    // Eased (smoothstep) pan over the pan window starting at the keyframe.
+    expect(graph.filterComplex).toContain('(t-5.000)/0.600')
+    expect(graph.filterComplex).toContain('(3-2*')
+    // The cut-flagged keyframe stays a hard constant step.
+    expect(graph.filterComplex).toContain(',0.2000)')
+  })
+
   it('applies auto zoom via the subpixel perspective filter, not zoompan', () => {
     const graph = buildFilterGraph(makeClip(), source, null, 30, null, {
       zoomEvents: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Auto-zoomed clips looked violently shaky whenever the clip was focused on a person — even after #21 replaced `zoompan` with the subpixel `perspective` zoom. That fix was correct for the zoom ramps themselves, but the shake users still saw came from the other half of the frame motion: the **auto-framing focus track**.

When the tracked speaker sways, gestures, or drifts (any normal on-camera movement), the face tracker emits a fresh focus keyframe every few seconds, and both the preview and the export treated *every* keyframe as a hard step — the crop lurched 100–250 px in a single frame, over and over. With the auto zoom pushed in, each lurch is magnified and reads as camera shake. Hard cuts are only the right behaviour for camera cuts and speaker switches; for the *same person moving within a shot* they are the bug.

Reproduced on a static looped frame (so all motion comes from the filter chain) with a moving-person focus track + auto zoom: mean-absolute-difference between consecutive output frames spiked to **~92–99** at every focus keyframe (vs ~0.1 during the zoom creep ramps, and ~3 at intentional zoom cuts).

## Fix

- `FocusKeyframe` gains an optional `cut` flag. `buildFocusTrack` sets it on run-start keyframes (camera cuts, speaker switches, clip start); within-shot refocuses of the same person are emitted with `cut: false`.
- Shared sampler (`src/shared/focusTrack.ts`): cut keyframes still snap instantly, within-shot moves are followed with a short (0.6 s) smoothstep-eased pan. Legacy tracks saved without the flag keep hard switches for large jumps (> 0.3 of frame width) and gain smooth pans for small ones.
- The export mirrors this exactly: `focusExpression` in `render.ts` now emits the same eased ramp as an ffmpeg crop expression, so preview (CSS `object-position`) and export move identically.
- Also fixes base-focus selection when the clip trim start is moved past several keyframes: the crop now starts from the *last* keyframe at or before the clip start, not the first keyframe of the track.

## Verification

- Same static-frame measurement after the fix: peak single-frame displacement at refocuses drops from MAD ~92–99 (single-frame lurch) to ~11 spread across the 0.6 s pan; intentional zoom cuts/snap-backs unchanged.
- `npm run typecheck`, `npm run lint`, `npm test` (115 tests, incl. new pan/snap coverage in `focusTrack.test.ts` and `render.test.ts`) all pass.
- Offline scripts `test-pipeline.ts` and `test-quality.ts` pass.
- Headless GUI smoke test passes:

[Editor screen after fix](https://cursor.com/agents/bc-85e06a5f-1260-447d-8e1f-1b0ff8630fdc/artifacts?path=%2Fworkspace%2F.tmp%2Fsmoke%2Feditor.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85e06a5f-1260-447d-8e1f-1b0ff8630fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85e06a5f-1260-447d-8e1f-1b0ff8630fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

