### PR TITLE
Fix preview zoom jitter (live editor, not export)

### DIFF
--- a/src/renderer/src/components/PreviewPlayer.tsx
+++ b/src/renderer/src/components/PreviewPlayer.tsx
@@ -4,16 +4,21 @@ import type { Clip, Project, WatermarkPosition } from '@shared/types'
 import { getCaptionStyle } from '@shared/captionStyles'
 import { groupWords, wordsInRange } from '@shared/captionLayout'
 import { computeKeptSegments, TimeMap } from '@shared/tighten'
-import { computeZoomEvents, zoomAt } from '@shared/zoom'
-import { focusAt } from '@shared/focusTrack'
+import { computeZoomEvents } from '@shared/zoom'
 import { formatTimecode } from '../lib/format'
+import {
+  smoothPlaybackTime,
+  type PlaybackClock,
+  type PreviewFramePlan
+} from '@shared/previewFrame'
+import { applyPreviewVideoFrame } from '../lib/previewVideo'
 import { usePreviewBus } from '../lib/previewBus'
 import { useStore } from '../store'
 
 /**
  * Live preview that mimics the exported result: bounded playback of the clip
- * range, CSS-simulated reframing (object-position matches the ffmpeg crop
- * focus) and word-level karaoke captions rendered from the transcript.
+ * range, CSS-simulated reframing (crop focus on the video, zoom on a wrapper
+ * — same order as ffmpeg) and word-level karaoke captions from the transcript.
  */
 export default function PreviewPlayer({
   project,
@@ -23,7 +28,16 @@ export default function PreviewPlayer({
   clip: Clip
 }): React.JSX.Element {
   const videoRef = useRef<HTMLVideoElement>(null)
+  const zoomLayerRef = useRef<HTMLDivElement>(null)
   const rafRef = useRef<number>(0)
+  const playbackClockRef = useRef<PlaybackClock>({ mediaTime: 0, wallAt: 0 })
+  const previewPlanRef = useRef<PreviewFramePlan>({
+    zoomEvents: null,
+    focusTrack: null,
+    framing: 'manual',
+    manualFocusX: 0.5,
+    isCrop: false
+  })
   /**
    * Seek requests issued while the browser is still completing a previous
    * seek are coalesced here and flushed on `seeked`. Setting currentTime on
@@ -45,6 +59,13 @@ export default function PreviewPlayer({
     [setBusTime]
   )
 
+  const applyFrame = useCallback((t: number): void => {
+    const video = videoRef.current
+    const layer = zoomLayerRef.current
+    if (!video || !layer) return
+    applyPreviewVideoFrame(video, layer, previewPlanRef.current, t)
+  }, [])
+
   const requestSeek = useCallback(
     (t: number): void => {
       const video = videoRef.current
@@ -55,9 +76,11 @@ export default function PreviewPlayer({
         pendingSeekRef.current = null
         video.currentTime = t
       }
+      playbackClockRef.current = { mediaTime: t, wallAt: performance.now() }
+      applyFrame(t)
       setTime(t)
     },
-    [setTime]
+    [setTime, applyFrame]
   )
 
   const handleSeeked = useCallback((): void => {
@@ -67,7 +90,11 @@ export default function PreviewPlayer({
     if (video && target !== null && Math.abs(video.currentTime - target) > 0.05) {
       video.currentTime = target
     }
-  }, [])
+    if (video) {
+      playbackClockRef.current = { mediaTime: video.currentTime, wallAt: performance.now() }
+      applyFrame(video.currentTime)
+    }
+  }, [applyFrame])
 
   const { start, end } = clip.edit
   const duration = Math.max(0.1, end - start)
@@ -119,7 +146,30 @@ export default function PreviewPlayer({
     const events = computeZoomEvents(project.transcript, start, end, keptSegments)
     return events.length > 0 ? events : null
   }, [clip.edit.autoZoom, project.transcript, start, end, keptSegments])
-  const zoom = zoomEvents ? zoomAt(zoomEvents, time) : 1
+
+  const src = window.clipforge.mediaUrl(project.video.path)
+  const isCrop = clip.edit.aspect !== 'original' && clip.edit.reframeMode === 'crop'
+  const isFitBlur = clip.edit.aspect !== 'original' && clip.edit.reframeMode === 'fit-blur'
+
+  useEffect(() => {
+    previewPlanRef.current = {
+      zoomEvents,
+      focusTrack: clip.focusTrack,
+      framing: clip.edit.framing,
+      manualFocusX: clip.edit.focusX,
+      isCrop
+    }
+    const t = videoRef.current?.currentTime ?? start
+    applyFrame(t)
+  }, [
+    zoomEvents,
+    clip.focusTrack,
+    clip.edit.framing,
+    clip.edit.focusX,
+    isCrop,
+    applyFrame,
+    start
+  ])
 
   useEffect(() => {
     const tick = (): void => {
@@ -130,26 +180,33 @@ export default function PreviewPlayer({
       if (video && !video.seeking && pendingSeekRef.current === null) {
         if (video.currentTime >= end) {
           video.currentTime = start
+          playbackClockRef.current = { mediaTime: start, wallAt: performance.now() }
         } else if (timeMap && !video.paused && timeMap.isRemoved(video.currentTime)) {
           const next = timeMap.nextKeptStart(video.currentTime)
           video.currentTime = next ?? end
+          playbackClockRef.current = { mediaTime: video.currentTime, wallAt: performance.now() }
         }
-        setTime(video.currentTime)
+        const smoothed = smoothPlaybackTime(video, playbackClockRef.current)
+        playbackClockRef.current = smoothed.clock
+        applyFrame(smoothed.t)
+        setTime(smoothed.t)
       }
       rafRef.current = requestAnimationFrame(tick)
     }
     if (playing) rafRef.current = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(rafRef.current)
-  }, [playing, start, end, timeMap, setTime])
+  }, [playing, start, end, timeMap, setTime, applyFrame])
 
   const togglePlay = (): void => {
     const video = videoRef.current
     if (!video) return
     if (playing) {
       video.pause()
+      playbackClockRef.current = { mediaTime: video.currentTime, wallAt: 0 }
       setPlaying(false)
     } else {
       if (video.currentTime >= end - 0.05) requestSeek(start)
+      playbackClockRef.current = { mediaTime: video.currentTime, wallAt: performance.now() }
       void video.play()
       setPlaying(true)
     }
@@ -162,14 +219,6 @@ export default function PreviewPlayer({
   const seek = (fraction: number): void => {
     requestSeek(start + fraction * duration)
   }
-
-  const src = window.clipforge.mediaUrl(project.video.path)
-  const isCrop = clip.edit.aspect !== 'original' && clip.edit.reframeMode === 'crop'
-  const isFitBlur = clip.edit.aspect !== 'original' && clip.edit.reframeMode === 'fit-blur'
-  const previewFocusX =
-    clip.edit.framing === 'auto' && clip.focusTrack
-      ? focusAt(clip.focusTrack, time)
-      : clip.edit.focusX
 
   return (
     <div className="flex h-full min-h-0 flex-col items-center gap-3">
@@ -184,23 +233,19 @@ export default function PreviewPlayer({
             className="absolute inset-0 h-full w-full scale-110 object-cover opacity-70 blur-2xl brightness-75"
           />
         )}
-        <video
-          ref={videoRef}
-          src={src}
-          poster={clip.thumbnailPath ? window.clipforge.mediaUrl(clip.thumbnailPath) : undefined}
-          className="relative h-full w-full"
-          style={{
-            objectFit: isCrop ? 'cover' : 'contain',
-            objectPosition: isCrop ? `${previewFocusX * 100}% 50%` : '50% 50%',
-            // Auto zoom, anchored where faces sit in vertical framing.
-            transform: zoom > 1.0001 ? `scale(${zoom.toFixed(4)})` : undefined,
-            transformOrigin: '50% 42%'
-          }}
-          onClick={togglePlay}
-          onEnded={() => setPlaying(false)}
-          onSeeked={handleSeeked}
-          preload="auto"
-        />
+        <div ref={zoomLayerRef} className="absolute inset-0 will-change-transform">
+          <video
+            ref={videoRef}
+            src={src}
+            poster={clip.thumbnailPath ? window.clipforge.mediaUrl(clip.thumbnailPath) : undefined}
+            className="h-full w-full"
+            style={{ objectFit: isCrop ? 'cover' : 'contain' }}
+            onClick={togglePlay}
+            onEnded={() => setPlaying(false)}
+            onSeeked={handleSeeked}
+            preload="auto"
+          />
+        </div>
         <BrollOverlay clip={clip} time={time} />
         <WatermarkOverlay />
         {clip.edit.captionsEnabled && project.transcript && (

--- a/src/renderer/src/lib/previewVideo.ts
+++ b/src/renderer/src/lib/previewVideo.ts
@@ -1,0 +1,16 @@
+import type { PreviewFramePlan } from '@shared/previewFrame'
+import { PREVIEW_ZOOM_ORIGIN_Y, previewFocusX, previewZoom } from '@shared/previewFrame'
+
+/** Apply crop focus and zoom directly to the preview DOM (bypasses React). */
+export function applyPreviewVideoFrame(
+  video: HTMLVideoElement,
+  zoomLayer: HTMLDivElement,
+  plan: PreviewFramePlan,
+  t: number
+): void {
+  const focusX = previewFocusX(plan, t)
+  const zoom = previewZoom(plan, t)
+  video.style.objectPosition = plan.isCrop ? `${focusX * 100}% 50%` : '50% 50%'
+  zoomLayer.style.transformOrigin = `50% ${PREVIEW_ZOOM_ORIGIN_Y * 100}%`
+  zoomLayer.style.transform = zoom > 1.0001 ? `scale(${zoom}) translateZ(0)` : 'translateZ(0)'
+}

--- a/src/shared/previewFrame.ts
+++ b/src/shared/previewFrame.ts
@@ -1,0 +1,62 @@
+import type { Clip, FocusKeyframe } from './types'
+import type { ZoomEvent } from './zoom'
+import { focusAt } from './focusTrack'
+import { zoomAt } from './zoom'
+
+/**
+ * Live-preview framing math shared with the renderer. The export runs crop
+ * then zoom as separate ffmpeg stages; the preview mirrors that split and
+ * must sample time smoothly — video.currentTime only advances at the decode
+ * frame rate while the display refreshes faster, which made slow zoom creeps
+ * stutter when zoom/focus were driven from coarse time steps.
+ */
+
+/** Vertical anchor matching ffmpeg perspective zoom (42% from top). */
+export const PREVIEW_ZOOM_ORIGIN_Y = 0.42
+
+export interface PlaybackClock {
+  mediaTime: number
+  wallAt: number
+}
+
+export interface PreviewFramePlan {
+  zoomEvents: ZoomEvent[] | null
+  focusTrack: FocusKeyframe[] | null
+  framing: Clip['edit']['framing']
+  manualFocusX: number
+  isCrop: boolean
+}
+
+/**
+ * Extrapolate playback time between coarse video.currentTime updates so slow
+ * zoom ramps advance every display frame, not just when the demuxer bumps time.
+ */
+export function smoothPlaybackTime(
+  video: { currentTime: number; paused: boolean; seeking: boolean },
+  clock: PlaybackClock,
+  wallNow = performance.now()
+): { t: number; clock: PlaybackClock } {
+  const raw = video.currentTime
+  if (video.paused || video.seeking) {
+    return { t: raw, clock: { mediaTime: raw, wallAt: wallNow } }
+  }
+  if (clock.wallAt === 0 || Math.abs(raw - clock.mediaTime) > 0.25) {
+    return { t: raw, clock: { mediaTime: raw, wallAt: wallNow } }
+  }
+  if (raw !== clock.mediaTime) {
+    return { t: raw, clock: { mediaTime: raw, wallAt: wallNow } }
+  }
+  return {
+    t: clock.mediaTime + (wallNow - clock.wallAt) / 1000,
+    clock
+  }
+}
+
+export function previewFocusX(plan: PreviewFramePlan, t: number): number {
+  if (plan.framing === 'auto' && plan.focusTrack) return focusAt(plan.focusTrack, t)
+  return plan.manualFocusX
+}
+
+export function previewZoom(plan: PreviewFramePlan, t: number): number {
+  return plan.zoomEvents ? zoomAt(plan.zoomEvents, t) : 1
+}

--- a/tests/previewFrame.test.ts
+++ b/tests/previewFrame.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  previewFocusX,
+  previewZoom,
+  smoothPlaybackTime,
+  type PreviewFramePlan
+} from '@shared/previewFrame'
+import type { ZoomEvent } from '@shared/zoom'
+
+const basePlan = (): PreviewFramePlan => ({
+  zoomEvents: null,
+  focusTrack: null,
+  framing: 'manual',
+  manualFocusX: 0.5,
+  isCrop: true
+})
+
+describe('smoothPlaybackTime', () => {
+  it('returns raw time when paused or seeking', () => {
+    expect(smoothPlaybackTime({ currentTime: 3, paused: true, seeking: false }, { mediaTime: 0, wallAt: 0 }).t).toBe(3)
+    expect(smoothPlaybackTime({ currentTime: 3, paused: false, seeking: true }, { mediaTime: 0, wallAt: 0 }).t).toBe(3)
+  })
+
+  it('extrapolates between currentTime updates while playing', () => {
+    const video = { currentTime: 10, paused: false, seeking: false }
+    const anchored = smoothPlaybackTime(video, { mediaTime: 10, wallAt: 1000 }, 1033.333)
+    expect(anchored.t).toBeCloseTo(10.0333, 3)
+    expect(anchored.clock.mediaTime).toBe(10)
+  })
+
+  it('re-anchors when currentTime advances', () => {
+    const video = { currentTime: 10.033, paused: false, seeking: false }
+    const next = smoothPlaybackTime(video, { mediaTime: 10, wallAt: 1000 }, 1033.333)
+    expect(next.clock.mediaTime).toBe(10.033)
+    expect(next.t).toBeCloseTo(10.033, 3)
+  })
+})
+
+describe('previewZoom', () => {
+  const creep: ZoomEvent[] = [{ start: 0, end: 8, from: 1, to: 1.08, style: 'creep' }]
+
+  it('interpolates zoom between coarse time steps', () => {
+    const plan = { ...basePlan(), zoomEvents: creep }
+    const a = previewZoom(plan, 0)
+    const b = previewZoom(plan, 4)
+    expect(b).toBeGreaterThan(a)
+    expect(previewZoom(plan, 8)).toBeCloseTo(1.08)
+  })
+})
+
+describe('previewFocusX', () => {
+  it('reads the auto focus track', () => {
+    const plan: PreviewFramePlan = {
+      ...basePlan(),
+      framing: 'auto',
+      focusTrack: [
+        { t: 0, x: 0.4, cut: true },
+        { t: 5, x: 0.6 }
+      ]
+    }
+    expect(previewFocusX(plan, 0)).toBeCloseTo(0.4)
+    const mid = previewFocusX(plan, 5.3)
+    expect(mid).toBeGreaterThan(0.4)
+    expect(mid).toBeLessThan(0.6)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

v0.6.4 fixed camera shake in **exports** (smooth focus pans + subpixel ffmpeg zoom), but the **live editor preview** still jittered during auto-zoom creeps — especially on clips focused on a person. Exports looked fine; only the pre-render view shook.

## Root cause

The preview diverged from the export pipeline in three ways:

1. **Same element for crop and zoom** — `object-position` (focus) and `transform: scale()` (zoom) were both applied on `<video>`. The export runs crop then zoom as separate stages; combining them on the video surface makes browsers round `object-position` to whole pixels, which reads as shake when zoomed in.

2. **Coarse time sampling** — zoom/focus were computed from `video.currentTime` (~30 Hz) but the display refreshes at 60+ Hz. Slow creep ramps advanced in visible steps between demuxer time updates.

3. **React-driven styles** — every rAF called `setState`, re-rendering the player and re-writing video styles through React instead of updating the DOM directly.

## Fix

- Split preview into two layers matching export order: **focus on the video**, **zoom on a wrapper div** (42% vertical anchor, same as ffmpeg `perspective`).
- **`smoothPlaybackTime`** extrapolates between `currentTime` updates while playing so creep ramps advance every display frame.
- Transform updates go through **direct DOM writes in rAF**, bypassing React for the video layer.
- Shared math in `src/shared/previewFrame.ts`; renderer applies it via `previewVideo.ts`.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` (141 tests, incl. new `previewFrame.test.ts`)
- Headless GUI smoke test passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85e06a5f-1260-447d-8e1f-1b0ff8630fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85e06a5f-1260-447d-8e1f-1b0ff8630fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

