### PR TITLE
Fix Whisper 404 when OPENAI_BASE_URL is empty or relative

### DIFF
--- a/src/main/pipeline/openai.ts
+++ b/src/main/pipeline/openai.ts
@@ -9,7 +9,45 @@ import { setTimeout as sleep } from 'node:timers/promises'
  * cancellation via AbortSignal.
  */
 
-const API_BASE = process.env.OPENAI_BASE_URL?.replace(/\/$/, '') ?? 'https://api.openai.com/v1'
+export const DEFAULT_OPENAI_API_BASE = 'https://api.openai.com/v1'
+
+/**
+ * Resolve the OpenAI REST base URL from OPENAI_BASE_URL. Empty, whitespace,
+ * relative values like "/v1", and other non-absolute URLs fall back to the
+ * default — otherwise fetch() posts to "/v1/audio/transcriptions" and Whisper
+ * fails with HTTP 404 "Invalid URL".
+ */
+export function resolveOpenAiApiBase(
+  envBase: string | undefined = process.env.OPENAI_BASE_URL
+): string {
+  const raw = envBase?.trim()
+  if (!raw) return DEFAULT_OPENAI_API_BASE
+
+  const trimmed = raw.replace(/\/$/, '')
+  if (!/^https?:\/\//i.test(trimmed)) {
+    console.warn(
+      `[clipforge] OPENAI_BASE_URL must be an absolute https URL (got ${JSON.stringify(raw)}); using ${DEFAULT_OPENAI_API_BASE}`
+    )
+    return DEFAULT_OPENAI_API_BASE
+  }
+
+  try {
+    const url = new URL(trimmed)
+    // api.openai.com serves the REST API under /v1 — accept the bare host too.
+    if (url.hostname === 'api.openai.com') {
+      const path = url.pathname.replace(/\/$/, '')
+      if (path === '' || path === '/') return `${url.origin}/v1`
+    }
+    return trimmed
+  } catch {
+    console.warn(
+      `[clipforge] OPENAI_BASE_URL is invalid (${JSON.stringify(raw)}); using ${DEFAULT_OPENAI_API_BASE}`
+    )
+    return DEFAULT_OPENAI_API_BASE
+  }
+}
+
+const API_BASE = resolveOpenAiApiBase()
 
 export class OpenAIError extends Error {
   constructor(

--- a/tests/openai.test.ts
+++ b/tests/openai.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DEFAULT_OPENAI_API_BASE, resolveOpenAiApiBase } from '../src/main/pipeline/openai'
+
+describe('resolveOpenAiApiBase', () => {
+  it('defaults when unset, empty, or whitespace', () => {
+    expect(resolveOpenAiApiBase(undefined)).toBe(DEFAULT_OPENAI_API_BASE)
+    expect(resolveOpenAiApiBase('')).toBe(DEFAULT_OPENAI_API_BASE)
+    expect(resolveOpenAiApiBase('   ')).toBe(DEFAULT_OPENAI_API_BASE)
+  })
+
+  it('rejects relative paths that make fetch post to /v1/audio/transcriptions', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    expect(resolveOpenAiApiBase('/v1')).toBe(DEFAULT_OPENAI_API_BASE)
+    expect(resolveOpenAiApiBase('v1')).toBe(DEFAULT_OPENAI_API_BASE)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('normalizes the bare OpenAI host to include /v1', () => {
+    expect(resolveOpenAiApiBase('https://api.openai.com')).toBe('https://api.openai.com/v1')
+    expect(resolveOpenAiApiBase('https://api.openai.com/')).toBe('https://api.openai.com/v1')
+  })
+
+  it('keeps explicit /v1 bases and third-party proxies unchanged', () => {
+    expect(resolveOpenAiApiBase('https://api.openai.com/v1')).toBe('https://api.openai.com/v1')
+    expect(resolveOpenAiApiBase('https://api.openai.com/v1/')).toBe('https://api.openai.com/v1')
+    expect(resolveOpenAiApiBase('https://openrouter.ai/api/v1')).toBe('https://openrouter.ai/api/v1')
+    expect(resolveOpenAiApiBase('https://proxy.example.com/v1')).toBe('https://proxy.example.com/v1')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Transcription fails with:

```
OpenAIError: Transcription failed (HTTP 404): Invalid URL (POST /v1/audio/transcriptions)
```

This is **unrelated to the v0.6.6 preview zoom changes** — those only touched the renderer preview layer. The failure comes from how `OPENAI_BASE_URL` is resolved in `openai.ts`.

## Root cause

`API_BASE` was built as:

```ts
process.env.OPENAI_BASE_URL?.replace(/\/$/, '') ?? 'https://api.openai.com/v1'
```

The `??` fallback only handles `null`/`undefined`. These all produce invalid fetch URLs:

| `OPENAI_BASE_URL` | Resulting fetch target |
|---|---|
| `""` (empty string) | `/audio/transcriptions` |
| `/v1` | `/v1/audio/transcriptions` ← matches the reported error |
| `   ` (whitespace) | `/audio/transcriptions` |

Node/fetch then posts to a relative path with no host, which surfaces as HTTP 404 "Invalid URL".

## Fix

- New `resolveOpenAiApiBase()` trims the env var, rejects non-absolute URLs with a console warning, normalizes `https://api.openai.com` → `https://api.openai.com/v1`, and leaves explicit proxy bases (OpenRouter, etc.) unchanged.
- Unit tests cover the failure cases.

## Workaround (before this ships)

On Windows, check whether `OPENAI_BASE_URL` is set in your environment or `.env`:

```powershell
echo $env:OPENAI_BASE_URL
```

If it's `/v1`, empty, or otherwise wrong, **unset it** (ClipForge only needs `OPENAI_API_KEY` for the official API):

```powershell
Remove-Item Env:OPENAI_BASE_URL
```

The `Cookies` / `Network` sandbox messages in the log are harmless Chromium startup noise on Windows and unrelated to this failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85e06a5f-1260-447d-8e1f-1b0ff8630fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85e06a5f-1260-447d-8e1f-1b0ff8630fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

