### PR TITLE
Improve clip moment selection and redesign the hook overlay

### DIFF
--- a/src/main/pipeline/captions.ts
+++ b/src/main/pipeline/captions.ts
@@ -98,6 +98,21 @@ export function buildAss(transcript: Transcript, opts: CaptionOptions): string {
   const primary = assStyleColor(style.textColor)
   const outline = assStyleColor(style.outlineColor)
 
+  // Hook "card": a filled, translucent rounded-feel label at the top. libass
+  // draws this with BorderStyle 3 (opaque box in the outline colour) plus a
+  // soft drop shadow (back colour), which reads as a modern hook overlay
+  // instead of bare floating text. Sized independently of the caption style so
+  // the hook stays prominent and legible whatever caption preset is chosen.
+  const titleFontSize = Math.round(opts.height * 0.044)
+  const titleMarginV = Math.round(opts.height * 0.07)
+  const titleMarginH = Math.round(opts.width * 0.1)
+  const titleBoxPad = Math.max(6, Math.round(opts.height * 0.009))
+  const titleShadow = Math.max(2, Math.round(opts.height * 0.0032))
+  /** Card fill: black at ~75% opacity (ASS alpha 0x40 = 25% transparent). */
+  const titleBox = '&H40000000'
+  /** Soft shadow: black at ~44% opacity. */
+  const titleShadowColor = '&H90000000'
+
   const header = `[Script Info]
 Title: ClipForge captions
 ScriptType: v4.00+
@@ -109,7 +124,7 @@ ScaledBorderAndShadow: yes
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
 Style: Caption,${style.fontFamily},${fontSize},${primary},${primary},${outline},&H80000000,${style.bold ? -1 : 0},0,0,0,100,100,0,0,1,${style.outlineWidth},${style.shadow},2,60,60,${marginV},1
-Style: Title,${style.fontFamily},${Math.round(fontSize * 0.82)},&H00FFFFFF,&H00FFFFFF,&H00000000,&H80000000,-1,0,0,0,100,100,0,0,1,3,1,8,60,60,${Math.round(opts.height * 0.08)},1
+Style: Title,${style.fontFamily},${titleFontSize},&H00FFFFFF,&H00FFFFFF,${titleBox},${titleShadowColor},-1,0,0,0,100,100,0,0,3,${titleBoxPad},${titleShadow},8,${titleMarginH},${titleMarginH},${titleMarginV},1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
@@ -121,7 +136,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
   if (opts.title && opts.title.trim().length > 0) {
     const showFor = Math.min(4, clipDur)
     lines.push(
-      `Dialogue: 1,${assTime(0)},${assTime(showFor)},Title,,0,0,0,,{\\fad(150,250)}${escapeAss(opts.title.trim())}`
+      `Dialogue: 1,${assTime(0)},${assTime(showFor)},Title,,0,0,0,,{\\fad(200,300)}${escapeAss(opts.title.trim())}`
     )
   }
 

--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -6,7 +6,7 @@ import type {
   Transcript
 } from '@shared/types'
 import { DEFAULT_CAPTION_STYLE_ID } from '@shared/captionStyles'
-import { normalizeClipEnd, sentenceEndTimes } from '@shared/sentences'
+import { normalizeClipEnd, sentenceEndTimes, sentenceStartTimes } from '@shared/sentences'
 import { chatJSON } from './openai'
 
 interface RawHighlight {
@@ -82,16 +82,41 @@ const RESPONSE_SCHEMA = {
   }
 } as const
 
+/**
+ * Length is a preference, not a straitjacket. We give the model a target band
+ * and a hard upper cap, but let it come in shorter when the moment is complete
+ * — a self-contained 20s beat beats the same beat padded to 30s with trailing
+ * filler. Platforms rank on completion rate, and padding a tight moment to hit
+ * a number is the fastest way to tank it, so we never pad after the fact.
+ */
 function lengthGuidance(pref: ClipLengthPreference): string {
   switch (pref) {
     case 'short':
-      return 'Each clip MUST be between 15 and 30 seconds long (end minus start).'
+      return 'Aim for clips around 15-30 seconds long (end minus start). Never exceed 45 seconds. If a moment is complete in less time, keep it short rather than padding it.'
     case 'medium':
-      return 'Each clip MUST be between 30 and 60 seconds long (end minus start).'
+      return 'Aim for clips around 30-60 seconds long (end minus start). Never exceed 75 seconds. Favour the length the moment actually needs — do not pad a complete moment to fill the range.'
     case 'long':
-      return 'Each clip MUST be between 60 and 90 seconds long (end minus start).'
+      return 'Aim for clips around 60-90 seconds long (end minus start). Never exceed 100 seconds. Only reach the top of the range when the moment genuinely sustains it; do not pad with setup or tangents.'
     case 'auto':
-      return 'Each clip MUST be between 15 and 90 seconds long (end minus start); choose whatever length lets the moment breathe.'
+      return 'Choose whatever length lets each moment land — anywhere from about 15 to 90 seconds (never exceed 100). Cut to the moment; do not pad it to reach a length.'
+    default: {
+      const exhaustive: never = pref
+      return exhaustive
+    }
+  }
+}
+
+/** Hard upper cap per preference, enforced after the LLM responds. */
+function maxDurationFor(pref: ClipLengthPreference): number {
+  switch (pref) {
+    case 'short':
+      return 45
+    case 'medium':
+      return 75
+    case 'long':
+      return 100
+    case 'auto':
+      return 100
     default: {
       const exhaustive: never = pref
       return exhaustive
@@ -111,6 +136,8 @@ const MIN_CLIP_SEC = 8
 
 /** Breathing room added before the first word of a clip. */
 const START_PRE_ROLL_SEC = 0.25
+/** How far the clip start may move to land on a sentence beginning. */
+const START_SNAP_SEC = 2.5
 /**
  * Tail padding after the last word so endings land softly instead of cutting
  * the instant the word finishes (the export adds an audio fade inside it).
@@ -118,24 +145,6 @@ const START_PRE_ROLL_SEC = 0.25
 const END_POST_ROLL_SEC = 0.6
 /** How far the clip end may move to land on a sentence boundary. */
 const SENTENCE_SNAP_SEC = 2.5
-
-/** Hard floor per length preference, enforced after the LLM responds. */
-function minDurationFor(pref: ClipLengthPreference): number {
-  switch (pref) {
-    case 'short':
-      return 15
-    case 'medium':
-      return 30
-    case 'long':
-      return 60
-    case 'auto':
-      return 15
-    default: {
-      const exhaustive: never = pref
-      return exhaustive
-    }
-  }
-}
 
 /**
  * The scoring rubric operationalises published virality research rather than
@@ -195,6 +204,13 @@ const MAX_END_EXTEND_SEC = 45
 const MAX_END_TRIM_SEC = 20
 /** How much transcript beyond a clip's end the ending review gets to see. */
 const CONTINUATION_SEC = 45
+
+/**
+ * How far the opening review may push a clip's start forward, i.e. the most
+ * leading setup it may trim. Bounded so the review can only drop throat-
+ * clearing, never lop off the body of a clip.
+ */
+const MAX_START_ADVANCE_SEC = 20
 
 function withNormalizedEnd(clip: Clip, transcript: Transcript, videoDurationSec: number): Clip {
   const end = normalizeClipEnd(clip.suggestedStart, clip.suggestedEnd, transcript, videoDurationSec, {
@@ -353,6 +369,134 @@ async function refineClipEndings(
   }
 }
 
+const REFINE_START_SYSTEM_PROMPT = `You quality-check the OPENINGS of short vertical clips cut from a longer video. The first 1-3 seconds decide whether a viewer keeps scrolling, so a clip must open on its HOOK — a bold claim, a surprising statement, a vivid moment, or a pointed question — not on throat-clearing, greetings, connective filler ("so", "and", "you know"), or setup whose only job is to lead into a later line.
+
+For each clip you receive its intended hook and its opening sentences, each tagged with the time it starts. Judge the current opening strictly. If it already opens on the hook, say so. If it opens on skippable setup and the real hook is one of the later tagged sentences, return that sentence's start time so the dead opening is trimmed. Rules: only move the start FORWARD, only to a time that appears in the tags, and never trim so far that the hook loses the context a cold viewer needs to understand it. When in doubt, leave the opening where it is.`
+
+interface RefinedStart {
+  index: number
+  opens_with_hook: boolean
+  better_start: number
+  reason: string
+}
+
+const REFINE_START_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['starts'],
+  properties: {
+    starts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['index', 'opens_with_hook', 'better_start', 'reason'],
+        properties: {
+          index: { type: 'integer', description: 'The clip number being judged' },
+          opens_with_hook: {
+            type: 'boolean',
+            description: 'True when the clip already opens on its hook (no trimming needed)'
+          },
+          better_start: {
+            type: 'number',
+            description:
+              'Start time (seconds) of the sentence where the hook begins; repeat the current start when opens_with_hook is true'
+          },
+          reason: { type: 'string', description: 'One short sentence justifying the verdict' }
+        }
+      }
+    }
+  }
+} as const
+
+/**
+ * Clamp and snap an opening-review suggestion onto a sentence beginning, or
+ * return the clip unchanged when the suggestion is a no-op, moves backwards,
+ * reaches too far, or would leave too little clip. Only ever advances the
+ * start (drops leading setup). Exported for tests.
+ */
+export function applyRefinedStart(clip: Clip, betterStart: number, sentenceStarts: number[]): Clip {
+  if (!Number.isFinite(betterStart)) return clip
+  const snapped = snap(betterStart, sentenceStarts, START_SNAP_SEC)
+  const newStart = Math.max(0, snapped - START_PRE_ROLL_SEC)
+  const current = clip.suggestedStart
+  if (
+    newStart <= current + 0.5 ||
+    newStart > current + MAX_START_ADVANCE_SEC ||
+    clip.suggestedEnd - newStart < MIN_CLIP_SEC
+  ) {
+    return clip
+  }
+  return { ...clip, suggestedStart: newStart, edit: { ...clip.edit, start: newStart } }
+}
+
+/**
+ * Second LLM pass mirroring the ending review, but on clip OPENINGS: verify
+ * each clip starts on its hook and push the start forward past leading setup
+ * when it does not. The first pass reliably finds hooks but often opens on a
+ * sentence or two of throat-clearing before them. Failures never break the
+ * pipeline; the unrefined clips are returned instead.
+ */
+async function refineClipStarts(
+  apiKey: string,
+  model: string,
+  transcript: Transcript,
+  clips: Clip[],
+  signal?: AbortSignal
+): Promise<Clip[]> {
+  if (clips.length === 0) return clips
+  const sentenceStarts = sentenceStartTimes(transcript)
+
+  const blocks = clips.map((clip, i) => {
+    // Only the first stretch of the clip is eligible to be trimmed, so we show
+    // just the opening sentences (plus a little slack) as candidates.
+    const openWindowEnd = clip.suggestedStart + MAX_START_ADVANCE_SEC + 5
+    const head = transcript.segments
+      .filter((s) => s.end > clip.suggestedStart + 0.2 && s.start < openWindowEnd)
+      .slice(0, 6)
+    return [
+      `Clip ${i} — intended hook: "${clip.hook || clip.title}" (currently starts at ${clip.suggestedStart.toFixed(1)}s):`,
+      ...head.map((s) => `  [starts ${s.start.toFixed(1)}s] ${s.text}`)
+    ].join('\n')
+  })
+
+  try {
+    const res = await chatJSON<{ starts: RefinedStart[] }>(
+      apiKey,
+      model,
+      [
+        { role: 'system', content: REFINE_START_SYSTEM_PROMPT },
+        {
+          role: 'user',
+          content: `Judge the opening of each clip below. Return one entry per clip, in order.\n\n${blocks.join('\n\n')}`
+        }
+      ],
+      'clip_openings',
+      REFINE_START_SCHEMA as unknown as Record<string, unknown>,
+      signal
+    )
+
+    const refined = [...clips]
+    for (const entry of res.starts ?? []) {
+      const clip = refined[entry.index]
+      if (!clip || entry.opens_with_hook) continue
+      refined[entry.index] = applyRefinedStart(clip, entry.better_start, sentenceStarts)
+      if (process.env.CLIPFORGE_DEBUG && refined[entry.index] !== clip) {
+        console.error(
+          `[highlights] opening review moved clip ${entry.index} start ` +
+            `${clip.suggestedStart.toFixed(1)}s -> ${refined[entry.index].suggestedStart.toFixed(1)}s: ${entry.reason}`
+        )
+      }
+    }
+    return refined
+  } catch (err) {
+    if (signal?.aborted) throw err
+    // The candidates are still usable without the opening review.
+    console.error('Clip opening review failed; keeping original starts:', err)
+    return clips
+  }
+}
+
 /**
  * Drop clips that substantially overlap a higher-scored clip, so the results
  * grid never shows two near-identical moments. Input must be sorted by score
@@ -390,8 +534,10 @@ export async function detectHighlights(
       ? first
       : await requestHighlights(apiKey, model, transcript, options, videoDurationSec, true, signal)
   const refined = await refineClipEndings(apiKey, model, transcript, clips, videoDurationSec, signal)
+  // Then trim any leading setup so each clip opens on its hook.
+  const hooked = await refineClipStarts(apiKey, model, transcript, refined, signal)
   // Refinement can pull two clips onto the same landing beat; dedupe again.
-  return dedupeClips(refined)
+  return dedupeClips(hooked)
 }
 
 async function requestHighlights(
@@ -454,8 +600,8 @@ async function requestHighlights(
       wordEnds.push(w.end)
     }
   }
-  const sentenceEnds = sentenceEndTimes(transcript)
-  const minDur = minDurationFor(options.clipLength)
+  const sentenceStarts = sentenceStartTimes(transcript)
+  const maxDur = maxDurationFor(options.clipLength)
   const normalizeEnd = (start: number, end: number): number =>
     normalizeClipEnd(start, end, transcript, videoDurationSec, {
       postRollSec: END_POST_ROLL_SEC,
@@ -470,23 +616,29 @@ async function requestHighlights(
   for (const raw of res.clips ?? []) {
     let start = Math.max(0, Math.min(raw.start, videoDurationSec - 1))
     let end = Math.max(start + 1, Math.min(raw.end, videoDurationSec))
-    // Snap the start to a word boundary for a clean cut, with a little pre-roll.
-    start = Math.max(0, snap(start, wordStarts, 1.5) - START_PRE_ROLL_SEC)
+    // Snap the start onto a sentence beginning so the clip opens on a clean
+    // thought, not mid-sentence, then add a little pre-roll. Falls back to the
+    // nearest word boundary when no sentence start is close enough.
+    const sentenceStart = snap(start, sentenceStarts, START_SNAP_SEC)
+    const snappedStart = sentenceStart !== start ? sentenceStart : snap(start, wordStarts, 1.5)
+    start = Math.max(0, snappedStart - START_PRE_ROLL_SEC)
     // Rough word snap, then extend to the next punctuated sentence end when the
     // model (or Whisper segment boundary) stopped mid-thought.
     end = Math.min(videoDurationSec, snap(end, wordEnds, 1.5) + END_POST_ROLL_SEC)
     end = normalizeEnd(start, end)
-    // Models often under-shoot durations: extend short clips to the next
-    // sentence boundary that satisfies the length preference — or to the end
-    // of the video when no sentence boundary is late enough.
-    if (end - start < minDur) {
-      const targetEnd = start + minDur
-      const nextSentenceEnd = sentenceEnds.find((e) => e + END_POST_ROLL_SEC >= targetEnd)
-      const extended =
-        nextSentenceEnd !== undefined
-          ? Math.min(videoDurationSec, nextSentenceEnd + END_POST_ROLL_SEC)
-          : Math.min(videoDurationSec, targetEnd + END_POST_ROLL_SEC)
-      end = normalizeEnd(start, extended)
+    // Length is a preference, not a floor: we never pad a complete moment to
+    // reach a target length (padding tanks completion rate). We only enforce
+    // the hard upper cap, trimming an over-long clip back to the last sentence
+    // that lands within the cap.
+    if (end - start > maxDur) {
+      const capTarget = start + maxDur
+      const lastSentenceEnd = [...sentenceEndTimes(transcript)]
+        .reverse()
+        .find((e) => e + END_POST_ROLL_SEC <= capTarget && e > start + MIN_CLIP_SEC)
+      end =
+        lastSentenceEnd !== undefined
+          ? Math.min(videoDurationSec, lastSentenceEnd + END_POST_ROLL_SEC)
+          : capTarget
     }
     if (end - start < Math.min(MIN_CLIP_SEC, videoDurationSec * 0.5)) {
       if (process.env.CLIPFORGE_DEBUG) {
@@ -517,7 +669,7 @@ async function requestHighlights(
         focusX: 0.5,
         captionsEnabled: true,
         captionStyleId: DEFAULT_CAPTION_STYLE_ID,
-        showTitle: false,
+        showTitle: true,
         start,
         end
       }

--- a/src/renderer/src/components/PreviewPlayer.tsx
+++ b/src/renderer/src/components/PreviewPlayer.tsx
@@ -255,21 +255,8 @@ export default function PreviewPlayer({
             time={time}
           />
         )}
-        {clip.edit.showTitle && time - start < Math.min(4, duration) && (
-          <div
-            className="pointer-events-none absolute inset-x-0 flex justify-center px-[6cqw] text-center"
-            style={{ top: '7cqh' }}
-          >
-            <span
-              className="font-extrabold text-white"
-              style={{
-                fontSize: '3.6cqh',
-                textShadow: '0 0 6px rgba(0,0,0,0.9), 2px 2px 0 rgba(0,0,0,0.8)'
-              }}
-            >
-              {clip.hook || clip.title}
-            </span>
-          </div>
+        {clip.edit.showTitle && (clip.hook || clip.title) && time - start < Math.min(4, duration) && (
+          <HookOverlay clip={clip} />
         )}
         {!playing && (
           <button
@@ -334,6 +321,40 @@ function WatermarkOverlay(): React.JSX.Element | null {
         ...corner[branding.position]
       }}
     />
+  )
+}
+
+/**
+ * Hook "card" shown for the first seconds of the clip. Mirrors the ASS Title
+ * style burned in on export (`captions.ts`): a filled translucent label at the
+ * top with a soft shadow, in the clip's caption font, so the preview matches
+ * the render.
+ */
+function HookOverlay({ clip }: { clip: Clip }): React.JSX.Element {
+  const style = getCaptionStyle(clip.edit.captionStyleId)
+  const fontFamily = clip.edit.captionFontFamily ?? style.fontFamily
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 flex justify-center px-[6cqw]"
+      style={{ top: '7cqh' }}
+    >
+      <span
+        className="hook-in inline-block max-w-[80cqw] text-center text-white"
+        style={{
+          fontFamily: `'${fontFamily}', sans-serif`,
+          fontWeight: 700,
+          fontSize: '4.4cqh',
+          lineHeight: 1.2,
+          padding: '0.7cqh 1.4cqh',
+          borderRadius: '0.8cqh',
+          backgroundColor: 'rgba(0,0,0,0.75)',
+          boxShadow: '0 0.4cqh 1.4cqh rgba(0,0,0,0.45)',
+          textWrap: 'balance'
+        }}
+      >
+        {clip.hook || clip.title}
+      </span>
+    </div>
   )
 }
 

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -115,3 +115,19 @@ input[type='range']::-webkit-slider-thumb {
 .caption-pop {
   animation: captionPop 90ms ease-out;
 }
+
+@keyframes hookIn {
+  0% {
+    opacity: 0;
+    transform: translateY(0.8cqh);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Mirrors the ASS \fad entrance on the burned-in hook card. */
+.hook-in {
+  animation: hookIn 220ms ease-out;
+}

--- a/src/shared/sentences.ts
+++ b/src/shared/sentences.ts
@@ -26,6 +26,27 @@ export function sentenceEndTimes(transcript: Transcript): number[] {
   return [...new Set(ends)].sort((a, b) => a - b)
 }
 
+/**
+ * Timestamps where a sentence begins: the first word of the transcript and
+ * the first word after any sentence-ending word. Used to snap a clip start
+ * onto a clean opening so clips never begin mid-thought, and to let the
+ * hook-first start review move the start to a later sentence.
+ */
+export function sentenceStartTimes(transcript: Transcript): number[] {
+  const starts: number[] = []
+  let atSentenceStart = true
+  for (const seg of transcript.segments) {
+    for (const w of seg.words) {
+      if (atSentenceStart) {
+        starts.push(w.start)
+        atSentenceStart = false
+      }
+      if (endsSentence(w.text)) atSentenceStart = true
+    }
+  }
+  return [...new Set(starts)].sort((a, b) => a - b)
+}
+
 export interface NormalizeClipEndOptions {
   postRollSec?: number
   /** How far the end may move forward to reach a sentence boundary. */

--- a/tests/highlights.test.ts
+++ b/tests/highlights.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { applyRefinedEnding, dedupeClips, targetClipCount } from '../src/main/pipeline/highlights'
+import {
+  applyRefinedEnding,
+  applyRefinedStart,
+  dedupeClips,
+  targetClipCount
+} from '../src/main/pipeline/highlights'
 import { DEFAULT_CAPTION_STYLE_ID } from '@shared/captionStyles'
 import type { Clip } from '@shared/types'
 
@@ -105,5 +110,38 @@ describe('applyRefinedEnding', () => {
   it('clamps to the end of the video', () => {
     const c = applyRefinedEnding(clip('a', 270, 290, 90), 299.8, [299.8], 300)
     expect(c.suggestedEnd).toBe(300)
+  })
+})
+
+describe('applyRefinedStart', () => {
+  const sentenceStarts = [5, 12, 20, 40]
+
+  it('advances the start to the sentence where the hook begins', () => {
+    const c = applyRefinedStart(clip('a', 5, 60, 90), 12.3, sentenceStarts)
+    // Snapped to the 12s sentence start minus the 0.25s pre-roll.
+    expect(c.suggestedStart).toBeCloseTo(11.75, 3)
+    expect(c.edit.start).toBeCloseTo(11.75, 3)
+    expect(c.suggestedEnd).toBe(60)
+  })
+
+  it('never rewinds the start to add setup', () => {
+    const original = clip('a', 12, 60, 90)
+    expect(applyRefinedStart(original, 5, sentenceStarts)).toBe(original)
+  })
+
+  it('ignores no-op, too-far and too-short suggestions', () => {
+    // Same start re-suggested: below the change threshold.
+    const original = clip('a', 5, 60, 90)
+    expect(applyRefinedStart(original, 5, sentenceStarts)).toBe(original)
+    // Advance beyond the 20s cap.
+    expect(applyRefinedStart(clip('a', 5, 60, 90), 40, sentenceStarts)).toEqual(
+      clip('a', 5, 60, 90)
+    )
+    // Trim that would leave the clip shorter than the minimum.
+    expect(applyRefinedStart(clip('a', 5, 15, 90), 12, sentenceStarts)).toEqual(
+      clip('a', 5, 15, 90)
+    )
+    // Nonsense values.
+    expect(applyRefinedStart(original, Number.NaN, sentenceStarts)).toBe(original)
   })
 })

--- a/tests/sentences.test.ts
+++ b/tests/sentences.test.ts
@@ -4,8 +4,32 @@ import {
   endsSentence,
   lastWordInClip,
   normalizeClipEnd,
-  sentenceEndTimes
+  sentenceEndTimes,
+  sentenceStartTimes
 } from '../src/shared/sentences'
+
+/** Two full sentences in one segment. */
+function twoSentences(): Transcript {
+  return {
+    language: 'english',
+    durationSec: 10,
+    segments: [
+      {
+        id: 0,
+        text: 'Hello there. This is next.',
+        start: 0,
+        end: 4,
+        words: [
+          { text: 'Hello', start: 0, end: 0.4 },
+          { text: 'there.', start: 0.5, end: 0.9 },
+          { text: 'This', start: 1.2, end: 1.5 },
+          { text: 'is', start: 1.6, end: 1.8 },
+          { text: 'next.', start: 1.9, end: 2.2 }
+        ]
+      }
+    ]
+  }
+}
 
 /** Whisper often breaks before the thought completes — e.g. segment ends on "so". */
 function transcriptEndingOnSo(): Transcript {
@@ -57,6 +81,16 @@ describe('sentenceEndTimes', () => {
   it('uses word punctuation, not Whisper segment ends', () => {
     const ends = sentenceEndTimes(transcriptEndingOnSo())
     expect(ends).toEqual([4.5])
+  })
+})
+
+describe('sentenceStartTimes', () => {
+  it('marks the first word and each word after a sentence end', () => {
+    expect(sentenceStartTimes(twoSentences())).toEqual([0, 1.2])
+  })
+
+  it('returns a single start for a one-sentence transcript', () => {
+    expect(sentenceStartTimes(transcriptEndingOnSo())).toEqual([0])
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Following an audit of how ClipForge decides what goes in each clip, its length, and how it crafts the "great moment," three issues stood out as the highest-leverage fixes. This PR addresses all three.

## What changed

### 1. Length is a preference, not a padded floor
Selection used to force any clip under a per-preference floor (`short` 15s / `medium` 30s / `long` 60s) up to length by extending it to the next sentence boundary, or to the end of the video. Padding a complete moment to hit a number is the single clearest own-goal against completion rate — the metric TikTok, Reels and Shorts all rank on ("the system penalizes inefficiency, not brevity").

- `lengthGuidance` is now a **target band with a hard upper cap**, and explicitly tells the model not to pad.
- Post-processing **never extends** a clip to reach a length; it only trims an over-long clip back to the last sentence within the cap.
- Endings are still completed to sentence boundaries (unchanged), and the ending-review pass is untouched.

### 2. Hook-first opening review
A new second review pass mirrors the existing (proven) ending review, but on clip **openings**. It judges whether each clip starts on its hook and pushes the start **forward** past leading setup ("so…", greetings, throat-clearing) when it does not. It is bounded (forward-only, max 20s of trim, never below the minimum clip length) and fully failure-safe — on any error the original clips are returned. Clip starts also now snap onto a **sentence beginning** so clips never open mid-thought.

### 3. Hook overlay redesigned and enabled by default
The overlay was off by default because bare floating white text wasn't visually appealing. It's now a **filled hook card** — a translucent label with bold high-contrast text and a soft drop shadow in the upper third. On-screen text hooks in the first frame are one of the highest-leverage retention levers, so it ships **on** by default.

The burn-in (ASS `Title` style, `BorderStyle 3` box + shadow) and the live preview (matching card in the caption font) render the same look, preserving the what-you-see-is-what-you-export guarantee.

Rendered export frame of the new card:

[Hook card burned into an exported clip](https://cursor.com/agents/bc-d2fb1f54-5eed-4f89-824b-ca361369c7e9/artifacts?path=%2Fworkspace%2F.artifacts%2Fhook-card.png)

## Testing
- `npm run typecheck` — passes
- `npm run lint` — passes
- `npx vitest run` — 146 passed (includes new `applyRefinedStart` and `sentenceStartTimes` tests)
- `scripts/test-quality.ts` (offline render, hook title enabled) — passes; the new ASS card burns in correctly under libass.

## Notes / deferred
The larger, more invasive editorial gap — full **non-contiguous condensing / cold-open reordering** (lifting the best line to second zero, dropping mid-clip tangents) — is intentionally out of scope here; it touches the `Clip` model, render concat, and caption/zoom/broll remapping, and warrants its own project. This PR ships the safe, contained first step (move the start to the hook).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2fb1f54-5eed-4f89-824b-ca361369c7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2fb1f54-5eed-4f89-824b-ca361369c7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

