### PR TITLE
Add WorkVivo integration: post clips to a space in one click

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,8 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { existsSync } from 'node:fs'
 import { copyFile, mkdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
 import { basename, extname, join } from 'node:path'
 import type {
   AnalyzeOptions,
@@ -16,6 +18,7 @@ import { probeVideo } from './pipeline/ffmpeg'
 import { getTimeline } from './pipeline/timeline'
 import { renderClip } from './pipeline/render'
 import { generateSocialCaption } from './pipeline/socialCaption'
+import { listSpaces, postClipToSpace, testConnection } from './pipeline/workvivo'
 import { addCustomFonts, listCustomFonts, removeCustomFont, renderFontsDir } from './fonts'
 import { clearImportCookiesFile, installImportCookiesFile } from './cookies'
 import { checkForUpdates, downloadUpdate, installUpdate, updateFromSource } from './updates'
@@ -28,14 +31,17 @@ import {
   getExportPreferences,
   getModelPreferences,
   getSettings,
+  getWorkvivoConfig,
   updateSettings
 } from './settings'
 
 const runningAnalyses = new Map<string, AbortController>()
 const runningExports = new Map<string, AbortController>()
+const runningWorkvivoPosts = new Map<string, AbortController>()
 
 export const ANALYSIS_CANCELLED_MESSAGE = 'Analysis cancelled'
 export const EXPORT_CANCELLED_MESSAGE = 'Export cancelled'
+export const WORKVIVO_POST_CANCELLED_MESSAGE = 'WorkVivo post cancelled'
 
 /** How far apart durations may be for a relinked file to count as the same video. */
 const RELINK_DURATION_TOLERANCE_SEC = 2
@@ -235,6 +241,95 @@ export function registerIpcHandlers(): void {
     clip.caption = caption
     await saveProject(project)
     return project
+  })
+
+  ipcMain.handle('workvivo:testConnection', async () => {
+    const cfg = getWorkvivoConfig()
+    if (!cfg) {
+      return { ok: false, message: 'Add your WorkVivo URL, Organisation ID and API key first.' }
+    }
+    return testConnection(cfg.request)
+  })
+
+  ipcMain.handle('workvivo:listSpaces', async () => {
+    const cfg = getWorkvivoConfig()
+    if (!cfg) return []
+    return listSpaces(cfg.request)
+  })
+
+  ipcMain.handle(
+    'workvivo:postClip',
+    async (event, projectId: string, clipId: string, spaceId: string) => {
+      const cfg = getWorkvivoConfig()
+      if (!cfg) {
+        throw new Error(
+          'WorkVivo is not connected. Add your URL, Organisation ID and API key in Settings.'
+        )
+      }
+      if (!spaceId) throw new Error('Choose a WorkVivo space to post to.')
+      const project = await loadProject(projectId)
+      const clip = project.clips.find((c) => c.id === clipId)
+      if (!clip) throw new Error('Clip not found')
+      if (project.sourceMissing) {
+        throw new Error(`The source video is missing (${project.video.path}). Relink it to post.`)
+      }
+      if (runningWorkvivoPosts.has(clipId)) throw new Error('This clip is already being posted.')
+
+      const text = (clip.caption?.trim() || clip.title || '').trim()
+      const prefs = getExportPreferences()
+      const branding = getBrandingSettings()
+      const controller = new AbortController()
+      runningWorkvivoPosts.set(clipId, controller)
+      const dir = join(tmpdir(), 'clipforge', 'workvivo')
+      await mkdir(dir, { recursive: true })
+      const outputPath = join(dir, `${clipId}-${randomUUID()}.mp4`)
+      const send = (progress: number, message: string): void => {
+        if (!event.sender.isDestroyed()) {
+          event.sender.send('workvivo:progress', { clipId, progress, message })
+        }
+      }
+      try {
+        send(0, 'Rendering clip…')
+        await renderClip({
+          clip,
+          source: project.video,
+          transcript: project.transcript,
+          outputPath,
+          encoder: prefs.encoder,
+          quality: prefs.quality,
+          branding:
+            branding.enabled && branding.imagePath && existsSync(branding.imagePath)
+              ? branding
+              : null,
+          fontsDirPath: await renderFontsDir(),
+          signal: controller.signal,
+          // Rendering is the first 80% of the job; upload is the rest.
+          onProgress: (fraction) => send(fraction * 0.8, 'Rendering clip…')
+        })
+        send(0.85, 'Uploading to WorkVivo…')
+        const result = await postClipToSpace(cfg.request, {
+          videoPath: outputPath,
+          text,
+          spaceId,
+          postAsUserId: cfg.postAsUserId || undefined,
+          signal: controller.signal
+        })
+        send(1, 'Posted to WorkVivo')
+        return result
+      } catch (err) {
+        if (controller.signal.aborted) {
+          throw new Error(WORKVIVO_POST_CANCELLED_MESSAGE, { cause: err })
+        }
+        throw err
+      } finally {
+        runningWorkvivoPosts.delete(clipId)
+        await rm(outputPath, { force: true }).catch(() => undefined)
+      }
+    }
+  )
+
+  ipcMain.handle('workvivo:cancelPost', async (_e, clipId: string) => {
+    runningWorkvivoPosts.get(clipId)?.abort()
   })
 
   ipcMain.handle('video:timeline', async (_e, videoPath: string, startSec: number, endSec: number) => {

--- a/src/main/pipeline/workvivo.ts
+++ b/src/main/pipeline/workvivo.ts
@@ -1,0 +1,207 @@
+import { readFile } from 'node:fs/promises'
+import { basename } from 'node:path'
+import type { WorkvivoPostResult, WorkvivoSpace, WorkvivoTestResult } from '@shared/types'
+
+/**
+ * Minimal WorkVivo Customer API client using Node's built-in fetch (no SDK).
+ *
+ * Auth model (confirmed against WorkVivo's docs and Zoom's own
+ * `zoom/workvivo-zoom-integration`): every request carries a Bearer token plus
+ * a `Workvivo-Id` header (the organisation id), against `<org-url>/api/v1`.
+ * This is an org-level app token, not the user's interactive SSO login, so
+ * posts are attributed to a configured identity (`user_id`) rather than
+ * whoever clicks.
+ *
+ * Endpoints:
+ * - `GET /spaces` — list spaces (used to power the picker + validate the
+ *   connection). Confirmed shape: `{ data: [{ id, name }] }`.
+ * - `POST /updates` — create a feed post targeted at a space, as
+ *   `multipart/form-data` with `text`, `space_id`, an optional `user_id`, and a
+ *   `video` file. The multipart video-upload pattern is confirmed from Zoom's
+ *   integration (which uses the sibling `/kudos` endpoint the same way); the
+ *   exact update-post endpoint/field names are centralised below so they are
+ *   trivial to adjust against developer.workvivo.com if an org's tenant differs.
+ */
+
+/** Feed-post endpoint and its field names, kept in one place (see file header). */
+const UPDATES_ENDPOINT = 'updates'
+const FIELD_TEXT = 'text'
+const FIELD_SPACE_ID = 'space_id'
+const FIELD_USER_ID = 'user_id'
+const FIELD_VIDEO = 'video'
+
+export interface WorkvivoRequestConfig {
+  /** Fully-qualified API base, e.g. https://acme.workvivo.com/api/v1. */
+  apiBase: string
+  /** Organisation id sent as the `Workvivo-Id` header. */
+  companyId: string
+  /** Bearer token. */
+  token: string
+}
+
+export class WorkvivoError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number
+  ) {
+    super(message)
+    this.name = 'WorkvivoError'
+  }
+}
+
+/**
+ * Derive the WorkVivo API base URL from an organisation's WorkVivo address.
+ * Accepts `https://acme.workvivo.com`, a bare `acme.workvivo.us`, or a URL that
+ * already includes a path — always returning `<origin>/api/v1`. Returns null
+ * when the value is not a usable host. Exported for tests.
+ */
+export function deriveWorkvivoApiBase(url: string | undefined): string | null {
+  const raw = url?.trim()
+  if (!raw) return null
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`
+  try {
+    const u = new URL(withScheme)
+    if (!u.hostname.includes('.')) return null
+    return `${u.origin}/api/v1`
+  } catch {
+    return null
+  }
+}
+
+function authHeaders(config: WorkvivoRequestConfig): Record<string, string> {
+  return {
+    'Workvivo-Id': config.companyId,
+    Authorization: `Bearer ${config.token}`,
+    Accept: 'application/json'
+  }
+}
+
+async function raiseForStatus(res: Response, context: string): Promise<never> {
+  let detail = ''
+  try {
+    const body = (await res.json()) as {
+      message?: string
+      error?: string
+      meta?: { errors?: unknown }
+    }
+    detail = body.message ?? body.error ?? (body.meta?.errors ? JSON.stringify(body.meta.errors) : '')
+  } catch {
+    /* non-JSON error body */
+  }
+  if (res.status === 401) {
+    throw new WorkvivoError('WorkVivo rejected the API key. Check the token in Settings.', 401)
+  }
+  if (res.status === 403) {
+    throw new WorkvivoError(
+      'WorkVivo denied the request — the token is missing the required scope (spaces:read / posting write).',
+      403
+    )
+  }
+  if (res.status === 404) {
+    throw new WorkvivoError(
+      `WorkVivo endpoint not found (HTTP 404). Check the WorkVivo URL and region (.com vs .us).`,
+      404
+    )
+  }
+  throw new WorkvivoError(`${context} failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`, res.status)
+}
+
+interface RawSpace {
+  id: string | number
+  name?: string
+  title?: string
+  display_name?: string
+}
+
+/** Normalise a WorkVivo space record from any of the observed name fields. */
+function toSpace(raw: RawSpace): WorkvivoSpace | null {
+  if (raw?.id === undefined || raw.id === null) return null
+  const name = raw.name ?? raw.title ?? raw.display_name ?? `Space ${raw.id}`
+  return { id: String(raw.id), name }
+}
+
+/** List the spaces the token can post to (first page). */
+export async function listSpaces(
+  config: WorkvivoRequestConfig,
+  signal?: AbortSignal
+): Promise<WorkvivoSpace[]> {
+  const res = await fetch(`${config.apiBase}/spaces?per_page=200`, {
+    method: 'GET',
+    headers: authHeaders(config),
+    signal
+  })
+  if (!res.ok) await raiseForStatus(res, 'Listing WorkVivo spaces')
+  const body = (await res.json()) as { data?: RawSpace[] }
+  const spaces = (body.data ?? [])
+    .map(toSpace)
+    .filter((s): s is WorkvivoSpace => s !== null)
+  spaces.sort((a, b) => a.name.localeCompare(b.name))
+  return spaces
+}
+
+/** Validate the connection by listing spaces. Never throws. */
+export async function testConnection(
+  config: WorkvivoRequestConfig,
+  signal?: AbortSignal
+): Promise<WorkvivoTestResult> {
+  try {
+    const spaces = await listSpaces(config, signal)
+    return {
+      ok: true,
+      message: `Connected — ${spaces.length} space${spaces.length === 1 ? '' : 's'} available.`,
+      spaceCount: spaces.length
+    }
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/** Pull a shareable post link out of WorkVivo's create response, if present. */
+export function extractPermalink(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return null
+  const b = body as { permalink?: unknown; url?: unknown; data?: { permalink?: unknown; url?: unknown } }
+  const candidates = [b.permalink, b.url, b.data?.permalink, b.data?.url]
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.length > 0) return c
+  }
+  return null
+}
+
+export interface PostClipOptions {
+  videoPath: string
+  /** Post body text (typically the AI social caption). */
+  text: string
+  /** Target space id. */
+  spaceId: string
+  /** WorkVivo user id to attribute the post to; omitted when empty. */
+  postAsUserId?: string
+  signal?: AbortSignal
+}
+
+/** Post a rendered clip to a WorkVivo space as a feed update with the video attached. */
+export async function postClipToSpace(
+  config: WorkvivoRequestConfig,
+  opts: PostClipOptions
+): Promise<WorkvivoPostResult> {
+  const bytes = await readFile(opts.videoPath)
+  const form = new FormData()
+  form.append(FIELD_TEXT, opts.text)
+  form.append(FIELD_SPACE_ID, opts.spaceId)
+  if (opts.postAsUserId) form.append(FIELD_USER_ID, opts.postAsUserId)
+  form.append(
+    FIELD_VIDEO,
+    new Blob([new Uint8Array(bytes)], { type: 'video/mp4' }),
+    basename(opts.videoPath)
+  )
+
+  const res = await fetch(`${config.apiBase}/${UPDATES_ENDPOINT}`, {
+    method: 'POST',
+    // Content-Type (with multipart boundary) is set by fetch from the FormData.
+    headers: authHeaders(config),
+    body: form,
+    signal: opts.signal
+  })
+  if (!res.ok) await raiseForStatus(res, 'Posting to WorkVivo')
+  const body = (await res.json().catch(() => ({}))) as unknown
+  return { ok: true, permalink: extractPermalink(body) }
+}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -7,10 +7,21 @@ import type {
   BrowserCookieSource,
   EncoderPreference,
   QualityPreference,
-  SettingsUpdate
+  SettingsUpdate,
+  WorkvivoPublicSettings
 } from '@shared/types'
 import { getGpuStatus } from './pipeline/encoders'
+import { deriveWorkvivoApiBase, type WorkvivoRequestConfig } from './pipeline/workvivo'
 import { clearImportCookiesFile, getImportCookiesPath } from './cookies'
+
+/** Persisted WorkVivo connection; token encrypted like the OpenAI key. */
+interface StoredWorkvivo {
+  url: string
+  companyId: string
+  tokenEncrypted: string
+  postAsUserId: string
+  defaultSpaceId: string
+}
 
 interface StoredSettings {
   /** Base64 of safeStorage-encrypted key, or plain 'plain:'-prefixed fallback. */
@@ -23,6 +34,7 @@ interface StoredSettings {
   quality: QualityPreference
   branding: BrandingSettings
   importCookiesBrowser: BrowserCookieSource
+  workvivo: StoredWorkvivo
 }
 
 const DEFAULT_BRANDING: BrandingSettings = {
@@ -31,6 +43,14 @@ const DEFAULT_BRANDING: BrandingSettings = {
   position: 'bottom-right',
   opacity: 0.8,
   scale: 0.16
+}
+
+const DEFAULT_WORKVIVO: StoredWorkvivo = {
+  url: '',
+  companyId: '',
+  tokenEncrypted: '',
+  postAsUserId: '',
+  defaultSpaceId: ''
 }
 
 const DEFAULTS: StoredSettings = {
@@ -45,7 +65,8 @@ const DEFAULTS: StoredSettings = {
   encoder: 'auto',
   quality: 'standard',
   branding: DEFAULT_BRANDING,
-  importCookiesBrowser: ''
+  importCookiesBrowser: '',
+  workvivo: DEFAULT_WORKVIVO
 }
 
 function settingsPath(): string {
@@ -62,8 +83,9 @@ function load(): StoredSettings {
       cache = {
         ...DEFAULTS,
         ...parsed,
-        // Nested object: merge so settings saved before new fields stay valid.
-        branding: { ...DEFAULT_BRANDING, ...(parsed.branding ?? {}) }
+        // Nested objects: merge so settings saved before new fields stay valid.
+        branding: { ...DEFAULT_BRANDING, ...(parsed.branding ?? {}) },
+        workvivo: { ...DEFAULT_WORKVIVO, ...(parsed.workvivo ?? {}) }
       }
       return cache
     }
@@ -123,7 +145,43 @@ export async function getSettings(): Promise<AppSettings> {
     branding: s.branding,
     appVersion: app.getVersion(),
     importCookiesBrowser: s.importCookiesBrowser,
-    hasImportCookiesFile: getImportCookiesPath() !== null
+    hasImportCookiesFile: getImportCookiesPath() !== null,
+    workvivo: getWorkvivoPublicSettings()
+  }
+}
+
+function getWorkvivoPublicSettings(): WorkvivoPublicSettings {
+  const w = load().workvivo
+  const token = decryptKey(w.tokenEncrypted)
+  return {
+    url: w.url,
+    companyId: w.companyId,
+    postAsUserId: w.postAsUserId,
+    defaultSpaceId: w.defaultSpaceId,
+    hasToken: token.length > 0,
+    tokenMasked: token.length > 8 ? `${token.slice(0, 4)}…${token.slice(-4)}` : token ? '•••' : '',
+    configured:
+      token.length > 0 && w.companyId.trim().length > 0 && deriveWorkvivoApiBase(w.url) !== null
+  }
+}
+
+/**
+ * Resolve the WorkVivo request config (API base, org id, decrypted token) plus
+ * posting preferences, or null when the integration is not fully configured.
+ */
+export function getWorkvivoConfig(): {
+  request: WorkvivoRequestConfig
+  postAsUserId: string
+  defaultSpaceId: string
+} | null {
+  const w = load().workvivo
+  const apiBase = deriveWorkvivoApiBase(w.url)
+  const token = decryptKey(w.tokenEncrypted)
+  if (!apiBase || !token || !w.companyId.trim()) return null
+  return {
+    request: { apiBase, companyId: w.companyId.trim(), token },
+    postAsUserId: w.postAsUserId.trim(),
+    defaultSpaceId: w.defaultSpaceId.trim()
   }
 }
 
@@ -180,6 +238,17 @@ export async function updateSettings(update: SettingsUpdate): Promise<AppSetting
   if (update.branding !== undefined) s.branding = { ...s.branding, ...update.branding }
   if (update.importCookiesBrowser !== undefined) s.importCookiesBrowser = update.importCookiesBrowser
   if (update.clearImportCookiesFile) await clearImportCookiesFile()
+  if (update.workvivo !== undefined) {
+    const w = update.workvivo
+    s.workvivo = {
+      ...s.workvivo,
+      ...(w.url !== undefined ? { url: w.url.trim() } : {}),
+      ...(w.companyId !== undefined ? { companyId: w.companyId.trim() } : {}),
+      ...(w.token !== undefined ? { tokenEncrypted: encryptKey(w.token.trim()) } : {}),
+      ...(w.postAsUserId !== undefined ? { postAsUserId: w.postAsUserId.trim() } : {}),
+      ...(w.defaultSpaceId !== undefined ? { defaultSpaceId: w.defaultSpaceId.trim() } : {})
+    }
+  }
   persist(s)
   return getSettings()
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,7 +15,11 @@ import type {
   SettingsUpdate,
   TimelineData,
   UpdateCheckResult,
-  UpdateDownloadProgress
+  UpdateDownloadProgress,
+  WorkvivoPostProgress,
+  WorkvivoPostResult,
+  WorkvivoSpace,
+  WorkvivoTestResult
 } from '@shared/types'
 
 const api = {
@@ -50,6 +54,22 @@ const api = {
   cancelExport: (clipId: string): Promise<void> => ipcRenderer.invoke('clip:cancelExport', clipId),
   generateCaption: (projectId: string, clipId: string): Promise<Project> =>
     ipcRenderer.invoke('clip:generateCaption', projectId, clipId),
+
+  testWorkvivo: (): Promise<WorkvivoTestResult> => ipcRenderer.invoke('workvivo:testConnection'),
+  listWorkvivoSpaces: (): Promise<WorkvivoSpace[]> => ipcRenderer.invoke('workvivo:listSpaces'),
+  postClipToWorkvivo: (
+    projectId: string,
+    clipId: string,
+    spaceId: string
+  ): Promise<WorkvivoPostResult> =>
+    ipcRenderer.invoke('workvivo:postClip', projectId, clipId, spaceId),
+  cancelWorkvivoPost: (clipId: string): Promise<void> =>
+    ipcRenderer.invoke('workvivo:cancelPost', clipId),
+  onWorkvivoProgress: (cb: (p: WorkvivoPostProgress) => void): (() => void) => {
+    const listener = (_e: Electron.IpcRendererEvent, p: WorkvivoPostProgress): void => cb(p)
+    ipcRenderer.on('workvivo:progress', listener)
+    return () => ipcRenderer.removeListener('workvivo:progress', listener)
+  },
 
   getTimeline: (videoPath: string, startSec: number, endSec: number): Promise<TimelineData> =>
     ipcRenderer.invoke('video:timeline', videoPath, startSec, endSec),

--- a/src/renderer/src/components/EditorScreen.tsx
+++ b/src/renderer/src/components/EditorScreen.tsx
@@ -12,10 +12,12 @@ import {
   Quote,
   ScanFace,
   Scissors,
+  Send,
   Share2,
   Sparkles,
   Trash2,
-  Type
+  Type,
+  X
 } from 'lucide-react'
 import type { TimelineData } from '@shared/types'
 import { useStore } from '../store'
@@ -556,7 +558,149 @@ function ShareSection({ clip }: { clip: Clip }): React.JSX.Element {
         only allows fully public in-app posting for audited web services, so this hand-off is
         the reliable local route.
       </p>
+      <WorkvivoPostBlock clip={clip} />
     </Section>
+  )
+}
+
+/**
+ * One-click posting of the current clip to a chosen WorkVivo space. Renders the
+ * clip and uploads it with the AI caption as the post text; falls back to a
+ * "connect it in Settings" prompt when the integration is not configured.
+ */
+function WorkvivoPostBlock({ clip }: { clip: Clip }): React.JSX.Element {
+  const settings = useStore((s) => s.settings)
+  const spaces = useStore((s) => s.workvivoSpaces)
+  const spacesError = useStore((s) => s.workvivoSpacesError)
+  const loadSpaces = useStore((s) => s.loadWorkvivoSpaces)
+  const post = useStore((s) => s.postClipToWorkvivo)
+  const cancel = useStore((s) => s.cancelWorkvivoPost)
+  const clear = useStore((s) => s.clearWorkvivoPost)
+  const entry = useStore((s) => s.workvivoPosts[clip.id])
+  const setSettingsOpen = useStore((s) => s.setSettingsOpen)
+  const configured = settings?.workvivo.configured ?? false
+  const defaultSpaceId = settings?.workvivo.defaultSpaceId ?? ''
+  const [picked, setPicked] = useState('')
+  // Effective selection: an explicit pick, else the configured default, else
+  // the first space. Computed (not stored) so no effect has to seed it.
+  const spaceId = picked || defaultSpaceId || spaces[0]?.id || ''
+
+  useEffect(() => {
+    if (configured) void loadSpaces()
+  }, [configured, loadSpaces])
+
+  if (!configured) {
+    return (
+      <div className="mt-3 border-t border-surface-700 pt-3">
+        <div className="mb-1.5 flex items-center gap-1.5 text-[11px] text-zinc-500">
+          <Send size={12} /> Post to WorkVivo
+        </div>
+        <button
+          onClick={() => setSettingsOpen(true)}
+          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-surface-600 px-3 py-2 text-xs font-medium text-zinc-300 transition hover:bg-surface-800"
+        >
+          <Send size={13} />
+          Connect WorkVivo in Settings
+        </button>
+        <p className="mt-1.5 text-[11px] leading-relaxed text-zinc-500">
+          Once connected, post this clip straight to a WorkVivo space with its caption in one click.
+        </p>
+      </div>
+    )
+  }
+
+  const posting = entry?.status === 'posting'
+
+  return (
+    <div className="mt-3 border-t border-surface-700 pt-3">
+      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] text-zinc-500">
+        <Send size={12} /> Post to WorkVivo
+      </div>
+      <select
+        value={spaceId}
+        onChange={(e) => setPicked(e.target.value)}
+        disabled={posting || spaces.length === 0}
+        className="w-full rounded-lg border border-surface-600 bg-surface-850 px-3 py-2 text-xs text-zinc-200 focus:border-white/25 focus:outline-none disabled:opacity-60"
+      >
+        {spaces.length === 0 ? (
+          <option value="">No spaces available</option>
+        ) : (
+          spaces.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))
+        )}
+      </select>
+      {spacesError && <p className="mt-1.5 text-[11px] leading-relaxed text-red-400">{spacesError}</p>}
+
+      {posting ? (
+        <div className="mt-2 rounded-lg border border-surface-600 px-3 py-2.5">
+          <div className="flex items-center justify-between gap-2 text-xs text-zinc-300">
+            <span className="flex items-center gap-2">
+              <Loader2 size={13} className="animate-spin" />
+              {entry.message || 'Posting…'}
+            </span>
+            <button
+              onClick={() => void cancel(clip.id)}
+              className="rounded-md p-1 text-zinc-500 transition hover:bg-surface-700 hover:text-zinc-200"
+              title="Cancel"
+            >
+              <X size={13} />
+            </button>
+          </div>
+          <div className="mt-2 h-1 overflow-hidden rounded-full bg-surface-700">
+            <div
+              className="h-full rounded-full bg-emerald-400 transition-all"
+              style={{ width: `${Math.round(Math.max(0, entry.progress) * 100)}%` }}
+            />
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => void post(clip.id, spaceId)}
+          disabled={!spaceId}
+          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/15 px-3 py-2 text-xs font-semibold text-emerald-400 transition hover:bg-emerald-500/25 disabled:opacity-40"
+        >
+          <Send size={13} />
+          Post to WorkVivo
+        </button>
+      )}
+
+      {entry?.status === 'done' && (
+        <div className="mt-2 flex items-center justify-between gap-2 rounded-lg bg-emerald-500/10 px-3 py-2 text-[11px] text-emerald-400">
+          <span className="flex items-center gap-1.5">
+            <Check size={13} /> Posted to WorkVivo
+          </span>
+          <span className="flex items-center gap-2">
+            {entry.permalink && (
+              <a
+                href={entry.permalink}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 underline decoration-emerald-500/40 underline-offset-2 hover:text-emerald-300"
+              >
+                View <ExternalLink size={11} />
+              </a>
+            )}
+            <button onClick={() => clear(clip.id)} className="text-emerald-400/70 hover:text-emerald-300">
+              <X size={12} />
+            </button>
+          </span>
+        </div>
+      )}
+      {entry?.status === 'error' && (
+        <div className="mt-2 rounded-lg bg-red-500/10 px-3 py-2 text-[11px] leading-relaxed text-red-400">
+          {entry.error}
+          <button onClick={() => clear(clip.id)} className="ml-2 underline hover:text-red-300">
+            dismiss
+          </button>
+        </div>
+      )}
+      <p className="mt-2 text-[11px] leading-relaxed text-zinc-500">
+        Renders the clip and uploads it with the caption above as the post text.
+      </p>
+    </div>
   )
 }
 

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -14,7 +14,8 @@ import {
   Zap,
   Download,
   Languages,
-  Loader2
+  Loader2,
+  Send
 } from 'lucide-react'
 import { useStore } from '../store'
 import type {
@@ -288,6 +289,7 @@ export default function SettingsModal(): React.JSX.Element {
         </div>
 
         <BrandingSection />
+        <WorkvivoSection />
         <FontsSection />
         <UpdatesSection />
 
@@ -415,6 +417,145 @@ function BrandingSection(): React.JSX.Element {
           </div>
         </>
       )}
+    </div>
+  )
+}
+
+/**
+ * WorkVivo connector: posts clips straight to a chosen WorkVivo space. Auth is
+ * an org-level app token (Bearer) plus the Organisation ID header — not the
+ * user's SSO login — so posts appear as the configured identity.
+ */
+function WorkvivoSection(): React.JSX.Element {
+  const settings = useStore((s) => s.settings)
+  const saveSettings = useStore((s) => s.saveSettings)
+  const spaces = useStore((s) => s.workvivoSpaces)
+  const loadSpaces = useStore((s) => s.loadWorkvivoSpaces)
+  const wv = settings?.workvivo
+  // Seeded once from settings, which are loaded before this modal can open.
+  const [url, setUrl] = useState(wv?.url ?? '')
+  const [companyId, setCompanyId] = useState(wv?.companyId ?? '')
+  const [token, setToken] = useState('')
+  const [postAsUserId, setPostAsUserId] = useState(wv?.postAsUserId ?? '')
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
+
+  useEffect(() => {
+    if (wv?.configured) void loadSpaces()
+  }, [wv?.configured, loadSpaces])
+
+  const saveAndTest = async (): Promise<void> => {
+    setBusy(true)
+    setResult(null)
+    try {
+      await saveSettings({
+        workvivo: {
+          url,
+          companyId,
+          postAsUserId,
+          ...(token.trim() ? { token: token.trim() } : {})
+        }
+      })
+      setToken('')
+      const test = await window.clipforge.testWorkvivo()
+      setResult(test)
+      if (test.ok) await loadSpaces()
+    } catch (err) {
+      setResult({ ok: false, message: err instanceof Error ? err.message : String(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const inputClass =
+    'mt-1.5 w-full rounded-xl border border-surface-600 bg-surface-850 px-3.5 py-2.5 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-white/25 focus:outline-none'
+
+  return (
+    <div className="mt-5 border-t border-surface-700 pt-5">
+      <label className="flex items-center gap-2 text-sm font-medium">
+        <Send size={15} className="text-accent-400" />
+        WorkVivo
+      </label>
+      <p className="mt-1 text-xs leading-relaxed text-zinc-500">
+        Post clips straight to a WorkVivo space. Uses an org app token (not your SSO login), so
+        posts appear as the identity below. Ask a WorkVivo admin to enable API access and mint a
+        token with the <span className="text-zinc-400">spaces:read</span> and posting scopes.
+      </p>
+
+      <div className="mt-3">
+        <span className="text-[11px] text-zinc-500">WorkVivo URL</span>
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://yourcompany.workvivo.com"
+          className={inputClass}
+        />
+      </div>
+      <div className="mt-3">
+        <span className="text-[11px] text-zinc-500">Organisation ID (Workvivo-Id)</span>
+        <input
+          value={companyId}
+          onChange={(e) => setCompanyId(e.target.value)}
+          placeholder="e.g. 12345"
+          className={inputClass}
+        />
+      </div>
+      <div className="mt-3">
+        <span className="text-[11px] text-zinc-500">API key (Bearer token)</span>
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder={wv?.hasToken ? `Current: ${wv.tokenMasked}` : 'Paste the API token'}
+          className={inputClass}
+        />
+      </div>
+      <div className="mt-3">
+        <span className="text-[11px] text-zinc-500">Post as — WorkVivo user ID (optional)</span>
+        <input
+          value={postAsUserId}
+          onChange={(e) => setPostAsUserId(e.target.value)}
+          placeholder="Shared Comms account user id"
+          className={inputClass}
+        />
+      </div>
+
+      {wv?.configured && spaces.length > 0 && (
+        <div className="mt-3">
+          <span className="text-[11px] text-zinc-500">Default space (optional)</span>
+          <select
+            value={wv.defaultSpaceId}
+            onChange={(e) => void saveSettings({ workvivo: { defaultSpaceId: e.target.value } })}
+            className={inputClass}
+          >
+            <option value="">No default</option>
+            {spaces.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {result && (
+        <p
+          className={`mt-3 rounded-lg px-3 py-2 text-xs leading-relaxed ${
+            result.ok ? 'bg-emerald-500/10 text-emerald-400' : 'bg-red-500/10 text-red-400'
+          }`}
+        >
+          {result.message}
+        </p>
+      )}
+
+      <button
+        onClick={() => void saveAndTest()}
+        disabled={busy}
+        className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-surface-600 px-3 py-2 text-xs font-medium text-zinc-300 transition hover:bg-surface-800 disabled:opacity-60"
+      >
+        {busy ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}
+        {busy ? 'Saving & testing…' : 'Save & test connection'}
+      </button>
     </div>
   )
 }

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -9,7 +9,8 @@ import type {
   Project,
   ProjectSummary,
   SettingsUpdate,
-  UpdateCheckResult
+  UpdateCheckResult,
+  WorkvivoSpace
 } from '@shared/types'
 
 /** Font faces already registered with document.fonts (FontFace API). */
@@ -46,6 +47,14 @@ export interface ExportEntry {
   error?: string
 }
 
+export interface WorkvivoPostEntry {
+  status: 'posting' | 'done' | 'error'
+  progress: number
+  message: string
+  permalink?: string | null
+  error?: string
+}
+
 interface AppState {
   screen: Screen
   project: Project | null
@@ -58,6 +67,9 @@ interface AppState {
   selectedClipId: string | null
   exports: Record<string, ExportEntry>
   exportDir: string | null
+  workvivoSpaces: WorkvivoSpace[]
+  workvivoSpacesError: string | null
+  workvivoPosts: Record<string, WorkvivoPostEntry>
   customFonts: CustomFont[]
   updateCheck: UpdateCheckResult | null
   checkingForUpdates: boolean
@@ -95,6 +107,10 @@ interface AppState {
   exportAll: () => Promise<void>
   chooseExportDir: () => Promise<void>
   clearExport: (clipId: string) => void
+  loadWorkvivoSpaces: () => Promise<void>
+  postClipToWorkvivo: (clipId: string, spaceId: string) => Promise<void>
+  cancelWorkvivoPost: (clipId: string) => Promise<void>
+  clearWorkvivoPost: (clipId: string) => void
   addFonts: () => Promise<void>
   removeFont: (fileName: string) => Promise<void>
   importCookiesFile: () => Promise<void>
@@ -118,6 +134,9 @@ export const useStore = create<AppState>((set, get) => ({
   selectedClipId: null,
   exports: {},
   exportDir: null,
+  workvivoSpaces: [],
+  workvivoSpacesError: null,
+  workvivoPosts: {},
   customFonts: [],
   updateCheck: null,
   checkingForUpdates: false,
@@ -144,6 +163,17 @@ export const useStore = create<AppState>((set, get) => ({
       const entry = get().exports[p.clipId]
       if (entry?.status === 'exporting') {
         set({ exports: { ...get().exports, [p.clipId]: { ...entry, progress: p.progress } } })
+      }
+    })
+    window.clipforge.onWorkvivoProgress((p) => {
+      const entry = get().workvivoPosts[p.clipId]
+      if (entry?.status === 'posting') {
+        set({
+          workvivoPosts: {
+            ...get().workvivoPosts,
+            [p.clipId]: { ...entry, progress: p.progress, message: p.message }
+          }
+        })
       }
     })
   },
@@ -376,6 +406,58 @@ export const useStore = create<AppState>((set, get) => ({
     const exports = { ...get().exports }
     delete exports[clipId]
     set({ exports })
+  },
+
+  loadWorkvivoSpaces: async () => {
+    if (!get().settings?.workvivo.configured) return
+    try {
+      const workvivoSpaces = await window.clipforge.listWorkvivoSpaces()
+      set({ workvivoSpaces, workvivoSpacesError: null })
+    } catch (err) {
+      set({ workvivoSpacesError: err instanceof Error ? cleanIpcError(err.message) : String(err) })
+    }
+  },
+
+  postClipToWorkvivo: async (clipId, spaceId) => {
+    const project = get().project
+    if (!project) return
+    set({
+      workvivoPosts: {
+        ...get().workvivoPosts,
+        [clipId]: { status: 'posting', progress: 0, message: 'Starting…' }
+      }
+    })
+    try {
+      const result = await window.clipforge.postClipToWorkvivo(project.id, clipId, spaceId)
+      set({
+        workvivoPosts: {
+          ...get().workvivoPosts,
+          [clipId]: { status: 'done', progress: 1, message: 'Posted', permalink: result.permalink }
+        }
+      })
+    } catch (err) {
+      const message = err instanceof Error ? cleanIpcError(err.message) : String(err)
+      if (message.includes('WorkVivo post cancelled')) {
+        get().clearWorkvivoPost(clipId)
+        return
+      }
+      set({
+        workvivoPosts: {
+          ...get().workvivoPosts,
+          [clipId]: { status: 'error', progress: 0, message: '', error: message }
+        }
+      })
+    }
+  },
+
+  cancelWorkvivoPost: async (clipId) => {
+    await window.clipforge.cancelWorkvivoPost(clipId)
+  },
+
+  clearWorkvivoPost: (clipId) => {
+    const workvivoPosts = { ...get().workvivoPosts }
+    delete workvivoPosts[clipId]
+    set({ workvivoPosts })
   },
 
   addFonts: async () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -274,6 +274,64 @@ export interface GpuEncoderStatus {
   canDownloadFfmpeg: boolean
 }
 
+/** A WorkVivo space (audience) a clip can be posted to. */
+export interface WorkvivoSpace {
+  id: string
+  name: string
+}
+
+/**
+ * Renderer-facing WorkVivo connection state. The Bearer token itself is never
+ * exposed — only whether one is stored and a masked hint, mirroring how the
+ * OpenAI key is surfaced.
+ */
+export interface WorkvivoPublicSettings {
+  /** Org WorkVivo URL, e.g. https://acme.workvivo.com. */
+  url: string
+  /** Organisation ID sent as the `Workvivo-Id` header. */
+  companyId: string
+  /** WorkVivo user id posts are attributed to (empty = the token's own user). */
+  postAsUserId: string
+  /** Preferred default space id for one-click posting ('' = none). */
+  defaultSpaceId: string
+  hasToken: boolean
+  tokenMasked: string
+  /** True when url + companyId + token are all present. */
+  configured: boolean
+}
+
+/** Partial WorkVivo config update; token is write-only. */
+export interface WorkvivoSettingsUpdate {
+  url?: string
+  companyId?: string
+  token?: string
+  postAsUserId?: string
+  defaultSpaceId?: string
+}
+
+/** Outcome of a WorkVivo "Test connection" call. */
+export interface WorkvivoTestResult {
+  ok: boolean
+  message: string
+  /** Number of spaces the token can see, when the test succeeded. */
+  spaceCount?: number
+}
+
+/** Outcome of posting a clip to WorkVivo. */
+export interface WorkvivoPostResult {
+  ok: boolean
+  /** Link to the created post, when WorkVivo returned one. */
+  permalink: string | null
+}
+
+/** Progress while rendering + uploading a clip to WorkVivo. */
+export interface WorkvivoPostProgress {
+  clipId: string
+  /** 0..1 overall (render then upload), or -1 when indeterminate. */
+  progress: number
+  message: string
+}
+
 export interface AppSettings {
   /** Masked key for display, e.g. "sk-...abcd". Empty string when unset. */
   apiKeyMasked: string
@@ -300,6 +358,8 @@ export interface AppSettings {
   importCookiesBrowser: BrowserCookieSource
   /** True when a Netscape cookies.txt file is stored for URL imports. */
   hasImportCookiesFile: boolean
+  /** WorkVivo posting integration. */
+  workvivo: WorkvivoPublicSettings
 }
 
 export interface SettingsUpdate {
@@ -312,6 +372,7 @@ export interface SettingsUpdate {
   branding?: Partial<BrandingSettings>
   importCookiesBrowser?: BrowserCookieSource
   clearImportCookiesFile?: boolean
+  workvivo?: WorkvivoSettingsUpdate
 }
 
 export interface PipelineError {

--- a/tests/workvivo.test.ts
+++ b/tests/workvivo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { deriveWorkvivoApiBase, extractPermalink } from '../src/main/pipeline/workvivo'
+
+describe('deriveWorkvivoApiBase', () => {
+  it('appends /api/v1 to a full org URL', () => {
+    expect(deriveWorkvivoApiBase('https://acme.workvivo.com')).toBe('https://acme.workvivo.com/api/v1')
+  })
+
+  it('handles the .us region', () => {
+    expect(deriveWorkvivoApiBase('https://acme.workvivo.us')).toBe('https://acme.workvivo.us/api/v1')
+  })
+
+  it('adds a scheme to a bare host', () => {
+    expect(deriveWorkvivoApiBase('acme.workvivo.com')).toBe('https://acme.workvivo.com/api/v1')
+  })
+
+  it('ignores any path already on the URL and uses the origin', () => {
+    expect(deriveWorkvivoApiBase('https://acme.workvivo.com/api/v1/')).toBe(
+      'https://acme.workvivo.com/api/v1'
+    )
+    expect(deriveWorkvivoApiBase('https://acme.workvivo.com/dashboard')).toBe(
+      'https://acme.workvivo.com/api/v1'
+    )
+  })
+
+  it('returns null for empty or unusable values', () => {
+    expect(deriveWorkvivoApiBase('')).toBeNull()
+    expect(deriveWorkvivoApiBase('   ')).toBeNull()
+    expect(deriveWorkvivoApiBase(undefined)).toBeNull()
+    expect(deriveWorkvivoApiBase('not a url')).toBeNull()
+    // A single-label host is not a real WorkVivo tenant.
+    expect(deriveWorkvivoApiBase('localhost')).toBeNull()
+  })
+})
+
+describe('extractPermalink', () => {
+  it('reads a top-level permalink or url', () => {
+    expect(extractPermalink({ permalink: 'https://x/comments/1' })).toBe('https://x/comments/1')
+    expect(extractPermalink({ url: 'https://x/p/2' })).toBe('https://x/p/2')
+  })
+
+  it('reads a nested data.permalink', () => {
+    expect(extractPermalink({ data: { permalink: 'https://x/comments/3' } })).toBe(
+      'https://x/comments/3'
+    )
+  })
+
+  it('returns null when no link is present', () => {
+    expect(extractPermalink({})).toBeNull()
+    expect(extractPermalink(null)).toBeNull()
+    expect(extractPermalink('nope')).toBeNull()
+    expect(extractPermalink({ data: {} })).toBeNull()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

A WorkVivo connector so the Comms team can push a finished clip straight to a WorkVivo **space** they select, in one click — with the AI caption as the post text.

### Settings → WorkVivo (new connector card)
- **WorkVivo URL** (e.g. `https://yourcompany.workvivo.com`) — used to derive the API base (`…/api/v1`) and region (`.com`/`.us`).
- **Organisation ID** — sent as the required `Workvivo-Id` header.
- **API key (Bearer token)** — stored **encrypted** via Electron `safeStorage` (same as the OpenAI key); only a masked hint is ever exposed to the UI.
- **Post as** (optional) — the WorkVivo user id posts are attributed to (a shared Comms account), since auth is an org app token, not per-user SSO.
- **Default space** (optional) + a **Save & test connection** button that validates via `GET /spaces`.

### Editor → Share → Post to WorkVivo
- A **space picker** (populated from the account) and a **Post to WorkVivo** button.
- One click **renders the clip** (respecting encoder/quality/branding, with progress + cancel) and **uploads the MP4** as a feed update to the chosen space, using the clip's caption as the post text.
- Shows progress, a **permalink** on success, and clear errors.

## How it talks to WorkVivo
Based on WorkVivo's docs and verified against Zoom's own `zoom/workvivo-zoom-integration`:
- Auth: `Authorization: Bearer <token>` + `Workvivo-Id: <org id>` against `<org-url>/api/v1`.
- `GET /spaces` — list audiences (confirmed shape `{ data: [{ id, name }] }`).
- `POST /updates` — multipart create with `text`, `space_id`, optional `user_id`, and a `video` file. The multipart video-upload pattern is confirmed from Zoom's integration (which uses the sibling `/kudos` endpoint the same way). The feed-post endpoint/field names are centralised as constants in `workvivo.ts` so they're trivial to adjust against `developer.workvivo.com` once a real tenant token is available.

## Testing
- `npm run typecheck`, `npm run lint` — pass
- `npx vitest run` — **158 passed**, incl. new tests for `deriveWorkvivoApiBase` (URL/region/base derivation) and `extractPermalink`
- GUI smoke test (build + Xvfb) — app builds and renders; Settings and Editor open without runtime errors

## Notes
- **Verification still pending on a live tenant.** All pure/derivable logic is tested, but the exact `POST /updates` endpoint + field names for a space-targeted feed post could not be confirmed against the token-gated API reference. They're isolated in one place for a quick adjustment. The connection test path (`GET /spaces`) uses the fully confirmed endpoint. Recommend a quick end-to-end check once an admin provisions a token (`spaces:read` + posting scope).
- Reads the rendered clip into memory to upload; fine for typical short clips.
- No secrets are logged or committed; the token lives only in encrypted app settings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2fb1f54-5eed-4f89-824b-ca361369c7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2fb1f54-5eed-4f89-824b-ca361369c7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

