### PR TITLE
Add brand colour defaults for captions and hook cards

### DIFF
--- a/src/main/pipeline/captions.ts
+++ b/src/main/pipeline/captions.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { app } from 'electron'
-import type { Transcript } from '@shared/types'
-import { getCaptionStyle, type CaptionStyle } from '@shared/captionStyles'
+import type { Transcript, BrandColors } from '@shared/types'
+import { resolveCaptionStyle, type CaptionStyle } from '@shared/captionStyles'
 import { groupWords, wordsInRange, type WordGroup } from '@shared/captionLayout'
 
 /**
@@ -76,6 +76,15 @@ function renderGroupText(group: WordGroup, activeIndex: number, style: CaptionSt
   return parts.join(' ')
 }
 
+/** "#RRGGBB" -> ASS style colour with explicit alpha "&HAA BB GGRR". */
+function assStyleColorWithAlpha(hex: string, alphaHex: string): string {
+  const clean = hex.replace('#', '')
+  const r = clean.slice(0, 2)
+  const g = clean.slice(2, 4)
+  const b = clean.slice(4, 6)
+  return `&H${alphaHex}${b}${g}${r}`.toUpperCase()
+}
+
 export interface CaptionOptions {
   styleId: string
   /** Output video dimensions the subtitles will be rendered onto. */
@@ -88,15 +97,25 @@ export interface CaptionOptions {
   title?: string
   /** Custom font family overriding the style's font (must exist in fontsdir). */
   fontFamily?: string
+  /** App-wide brand palette merged onto the caption preset. */
+  brandColors?: BrandColors | null
 }
 
 export function buildAss(transcript: Transcript, opts: CaptionOptions): string {
-  const preset = getCaptionStyle(opts.styleId)
-  const style = opts.fontFamily ? { ...preset, fontFamily: opts.fontFamily } : preset
+  const style = resolveCaptionStyle(opts.styleId, opts.brandColors, opts.fontFamily)
   const fontSize = Math.round(style.fontScale * opts.height)
   const marginV = Math.round((1 - style.positionY) * opts.height)
   const primary = assStyleColor(style.textColor)
   const outline = assStyleColor(style.outlineColor)
+  const brandColors = opts.brandColors
+  const hookText = assStyleColor(
+    brandColors?.enabled ? brandColors.hookTextColor : '#FFFFFF'
+  )
+  const titleBox = brandColors?.enabled
+    ? assStyleColorWithAlpha(brandColors.hookBackgroundColor, '40')
+    : '&H40000000'
+  /** Soft shadow: black at ~44% opacity. */
+  const titleShadowColor = '&H90000000'
 
   // Hook "card": a filled, translucent rounded-feel label at the top. libass
   // draws this with BorderStyle 3 (opaque box in the outline colour) plus a
@@ -108,10 +127,6 @@ export function buildAss(transcript: Transcript, opts: CaptionOptions): string {
   const titleMarginH = Math.round(opts.width * 0.1)
   const titleBoxPad = Math.max(6, Math.round(opts.height * 0.009))
   const titleShadow = Math.max(2, Math.round(opts.height * 0.0032))
-  /** Card fill: black at ~75% opacity (ASS alpha 0x40 = 25% transparent). */
-  const titleBox = '&H40000000'
-  /** Soft shadow: black at ~44% opacity. */
-  const titleShadowColor = '&H90000000'
 
   const header = `[Script Info]
 Title: ClipForge captions
@@ -124,7 +139,7 @@ ScaledBorderAndShadow: yes
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
 Style: Caption,${style.fontFamily},${fontSize},${primary},${primary},${outline},&H80000000,${style.bold ? -1 : 0},0,0,0,100,100,0,0,1,${style.outlineWidth},${style.shadow},2,60,60,${marginV},1
-Style: Title,${style.fontFamily},${titleFontSize},&H00FFFFFF,&H00FFFFFF,${titleBox},${titleShadowColor},-1,0,0,0,100,100,0,0,3,${titleBoxPad},${titleShadow},8,${titleMarginH},${titleMarginH},${titleMarginV},1
+Style: Title,${style.fontFamily},${titleFontSize},${hookText},${hookText},${titleBox},${titleShadowColor},-1,0,0,0,100,100,0,0,3,${titleBoxPad},${titleShadow},8,${titleMarginH},${titleMarginH},${titleMarginV},1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text

--- a/src/main/pipeline/render.ts
+++ b/src/main/pipeline/render.ts
@@ -418,7 +418,8 @@ export async function renderClip(job: RenderJob): Promise<string> {
       clipStart: captionStart,
       clipEnd: captionEnd,
       title: clip.edit.showTitle ? clip.hook || clip.title : undefined,
-      fontFamily: clip.edit.captionFontFamily ?? undefined
+      fontFamily: clip.edit.captionFontFamily ?? undefined,
+      brandColors: job.branding?.colors
     })
     const dir = join(tmpdir(), 'clipforge')
     await mkdir(dir, { recursive: true })

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -13,6 +13,7 @@ import type {
 import { getGpuStatus } from './pipeline/encoders'
 import { deriveWorkvivoApiBase, type WorkvivoRequestConfig } from './pipeline/workvivo'
 import { clearImportCookiesFile, getImportCookiesPath } from './cookies'
+import { DEFAULT_BRAND_COLORS } from '@shared/captionStyles'
 
 /** Persisted WorkVivo connection; token encrypted like the OpenAI key. */
 interface StoredWorkvivo {
@@ -42,7 +43,8 @@ const DEFAULT_BRANDING: BrandingSettings = {
   imagePath: null,
   position: 'bottom-right',
   opacity: 0.8,
-  scale: 0.16
+  scale: 0.16,
+  colors: DEFAULT_BRAND_COLORS
 }
 
 const DEFAULT_WORKVIVO: StoredWorkvivo = {
@@ -84,7 +86,11 @@ function load(): StoredSettings {
         ...DEFAULTS,
         ...parsed,
         // Nested objects: merge so settings saved before new fields stay valid.
-        branding: { ...DEFAULT_BRANDING, ...(parsed.branding ?? {}) },
+        branding: {
+          ...DEFAULT_BRANDING,
+          ...(parsed.branding ?? {}),
+          colors: { ...DEFAULT_BRAND_COLORS, ...(parsed.branding?.colors ?? {}) }
+        },
         workvivo: { ...DEFAULT_WORKVIVO, ...(parsed.workvivo ?? {}) }
       }
       return cache
@@ -235,7 +241,14 @@ export async function updateSettings(update: SettingsUpdate): Promise<AppSetting
   }
   if (update.encoder !== undefined) s.encoder = update.encoder
   if (update.quality !== undefined) s.quality = update.quality
-  if (update.branding !== undefined) s.branding = { ...s.branding, ...update.branding }
+  if (update.branding !== undefined) {
+    const b = update.branding
+    s.branding = {
+      ...s.branding,
+      ...b,
+      ...(b.colors !== undefined ? { colors: { ...s.branding.colors, ...b.colors } } : {})
+    }
+  }
   if (update.importCookiesBrowser !== undefined) s.importCookiesBrowser = update.importCookiesBrowser
   if (update.clearImportCookiesFile) await clearImportCookiesFile()
   if (update.workvivo !== undefined) {

--- a/src/renderer/src/components/EditorScreen.tsx
+++ b/src/renderer/src/components/EditorScreen.tsx
@@ -26,7 +26,7 @@ import TrimBar from './TrimBar'
 import ScoreBadge from './ScoreBadge'
 import TranscriptEditor from './TranscriptEditor'
 import { ExportButton } from './ClipsScreen'
-import { CAPTION_STYLES } from '@shared/captionStyles'
+import { CAPTION_STYLES, resolveCaptionStyle } from '@shared/captionStyles'
 import { formatTimecode } from '../lib/format'
 import type { AspectRatio, BrollItem, BrollMode, Clip, FramingMode, ReframeMode } from '@shared/types'
 
@@ -46,6 +46,7 @@ export default function EditorScreen(): React.JSX.Element {
   const cancelExport = useStore((s) => s.cancelExport)
   const exports = useStore((s) => s.exports)
   const customFonts = useStore((s) => s.customFonts)
+  const brandColors = useStore((s) => s.settings?.branding.colors)
 
   const clip = project?.clips.find((c) => c.id === selectedClipId) ?? null
 
@@ -265,12 +266,14 @@ export default function EditorScreen(): React.JSX.Element {
           />
           {clip.edit.captionsEnabled && (
             <div className="mt-3 grid grid-cols-2 gap-2">
-              {CAPTION_STYLES.map((style) => (
+              {CAPTION_STYLES.map((preset) => {
+                const style = resolveCaptionStyle(preset.id, brandColors)
+                return (
                 <button
-                  key={style.id}
-                  onClick={() => set({ captionStyleId: style.id })}
+                  key={preset.id}
+                  onClick={() => set({ captionStyleId: preset.id })}
                   className={`rounded-xl border px-3 py-2.5 text-left transition ${
-                    clip.edit.captionStyleId === style.id
+                    clip.edit.captionStyleId === preset.id
                       ? 'border-white/30 bg-white/[0.07]'
                       : 'border-surface-600 hover:bg-surface-800'
                   }`}
@@ -295,9 +298,9 @@ export default function EditorScreen(): React.JSX.Element {
                       {style.uppercase ? 'SAID' : 'said'}
                     </span>
                   </div>
-                  <div className="mt-1 text-[11px] text-zinc-500">{style.name}</div>
+                  <div className="mt-1 text-[11px] text-zinc-500">{preset.name}</div>
                 </button>
-              ))}
+              )})}
             </div>
           )}
           {clip.edit.captionsEnabled && (

--- a/src/renderer/src/components/PreviewPlayer.tsx
+++ b/src/renderer/src/components/PreviewPlayer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Play, Pause, RotateCcw } from 'lucide-react'
 import type { Clip, Project, WatermarkPosition } from '@shared/types'
-import { getCaptionStyle } from '@shared/captionStyles'
+import { hexToRgba, resolveCaptionStyle } from '@shared/captionStyles'
 import { groupWords, wordsInRange } from '@shared/captionLayout'
 import { computeKeptSegments, TimeMap } from '@shared/tighten'
 import { computeZoomEvents } from '@shared/zoom'
@@ -331,23 +331,32 @@ function WatermarkOverlay(): React.JSX.Element | null {
  * the render.
  */
 function HookOverlay({ clip }: { clip: Clip }): React.JSX.Element {
-  const style = getCaptionStyle(clip.edit.captionStyleId)
-  const fontFamily = clip.edit.captionFontFamily ?? style.fontFamily
+  const brandColors = useStore((s) => s.settings?.branding.colors)
+  const style = resolveCaptionStyle(
+    clip.edit.captionStyleId,
+    brandColors,
+    clip.edit.captionFontFamily
+  )
+  const hookTextColor = brandColors?.enabled ? brandColors.hookTextColor : '#FFFFFF'
+  const hookBackgroundColor = brandColors?.enabled
+    ? hexToRgba(brandColors.hookBackgroundColor, 0.75)
+    : 'rgba(0,0,0,0.75)'
   return (
     <div
       className="pointer-events-none absolute inset-x-0 flex justify-center px-[6cqw]"
       style={{ top: '7cqh' }}
     >
       <span
-        className="hook-in inline-block max-w-[80cqw] text-center text-white"
+        className="hook-in inline-block max-w-[80cqw] text-center"
         style={{
-          fontFamily: `'${fontFamily}', sans-serif`,
+          fontFamily: `'${style.fontFamily}', sans-serif`,
           fontWeight: 700,
           fontSize: '4.4cqh',
           lineHeight: 1.2,
+          color: hookTextColor,
           padding: '0.7cqh 1.4cqh',
           borderRadius: '0.8cqh',
-          backgroundColor: 'rgba(0,0,0,0.75)',
+          backgroundColor: hookBackgroundColor,
           boxShadow: '0 0.4cqh 1.4cqh rgba(0,0,0,0.45)',
           textWrap: 'balance'
         }}
@@ -397,7 +406,12 @@ function CaptionOverlay({
   clip: Clip
   time: number
 }): React.JSX.Element | null {
-  const style = getCaptionStyle(clip.edit.captionStyleId)
+  const brandColors = useStore((s) => s.settings?.branding.colors)
+  const style = resolveCaptionStyle(
+    clip.edit.captionStyleId,
+    brandColors,
+    clip.edit.captionFontFamily
+  )
 
   const groups = useMemo(() => {
     const words = wordsInRange(transcript, clip.edit.start, clip.edit.end)
@@ -419,7 +433,7 @@ function CaptionOverlay({
     >
       <div
         style={{
-          fontFamily: `'${clip.edit.captionFontFamily ?? style.fontFamily}', sans-serif`,
+          fontFamily: `'${style.fontFamily}', sans-serif`,
           fontSize: `${style.fontScale * 100}cqh`,
           fontWeight: style.bold ? 700 : 400,
           lineHeight: 1.25,

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -15,10 +15,13 @@ import {
   Download,
   Languages,
   Loader2,
-  Send
+  Send,
+  Palette
 } from 'lucide-react'
 import { useStore } from '../store'
+import { DEFAULT_BRAND_COLORS, resolveCaptionStyle } from '@shared/captionStyles'
 import type {
+  BrandColors,
   EncoderPreference,
   ImportProgress,
   QualityPreference,
@@ -311,6 +314,11 @@ function BrandingSection(): React.JSX.Element {
   const saveSettings = useStore((s) => s.saveSettings)
   const selectBrandingLogo = useStore((s) => s.selectBrandingLogo)
   const branding = settings?.branding
+  const colors = branding?.colors ?? DEFAULT_BRAND_COLORS
+
+  const saveColors = (patch: Partial<BrandColors>): void => {
+    void saveSettings({ branding: { colors: { ...colors, ...patch } } })
+  }
 
   return (
     <div className="mt-5 border-t border-surface-700 pt-5">
@@ -319,6 +327,111 @@ function BrandingSection(): React.JSX.Element {
         Branding
       </label>
       <p className="mt-1 text-xs leading-relaxed text-zinc-500">
+        Set your logo, watermark, and brand colours. Colours apply as defaults across every
+        caption style in the preview and exports.
+      </p>
+
+      <div className="mt-4 rounded-xl border border-surface-700 bg-surface-850 p-4">
+        <div className="flex items-center gap-2 text-sm font-medium text-zinc-200">
+          <Palette size={15} className="text-accent-400" />
+          Brand colours
+        </div>
+        <p className="mt-1 text-[11px] leading-relaxed text-zinc-500">
+          Primary is the highlight or pill fill; secondary is the active-word text on pill styles.
+          Leave text/outline on preset to keep each style&apos;s defaults.
+        </p>
+
+        <div className="mt-2.5 flex items-center justify-between gap-3 rounded-lg border border-surface-600 px-3 py-2.5">
+          <span className="text-xs font-medium text-zinc-300">Use brand colours on captions</span>
+          <button
+            onClick={() => saveColors({ enabled: !colors.enabled })}
+            className={`relative h-5 w-9 shrink-0 rounded-full transition ${colors.enabled ? 'bg-zinc-100' : 'bg-surface-600'}`}
+          >
+            <span
+              className={`absolute top-0.5 h-4 w-4 rounded-full transition-all ${colors.enabled ? 'left-[18px] bg-zinc-900' : 'left-0.5 bg-white'}`}
+            />
+          </button>
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-3">
+          <ColorField
+            label="Primary"
+            value={colors.primaryColor}
+            onChange={(v) => saveColors({ primaryColor: v })}
+          />
+          <ColorField
+            label="Secondary"
+            value={colors.secondaryColor}
+            onChange={(v) => saveColors({ secondaryColor: v })}
+          />
+          <ColorField
+            label="Caption text"
+            value={colors.textColor ?? ''}
+            pickerFallback="#FFFFFF"
+            placeholder="Style default"
+            onChange={(v) => saveColors({ textColor: v })}
+            onClear={colors.textColor ? () => saveColors({ textColor: null }) : undefined}
+          />
+          <ColorField
+            label="Outline"
+            value={colors.outlineColor ?? ''}
+            pickerFallback="#000000"
+            placeholder="Style default"
+            onChange={(v) => saveColors({ outlineColor: v })}
+            onClear={colors.outlineColor ? () => saveColors({ outlineColor: null }) : undefined}
+          />
+          <ColorField
+            label="Hook text"
+            value={colors.hookTextColor}
+            onChange={(v) => saveColors({ hookTextColor: v })}
+          />
+          <ColorField
+            label="Hook background"
+            value={colors.hookBackgroundColor}
+            onChange={(v) => saveColors({ hookBackgroundColor: v })}
+          />
+        </div>
+
+        <div className="mt-3 rounded-lg border border-surface-600 bg-black/40 px-3 py-2.5">
+          <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-zinc-500">
+            Preview
+          </div>
+          {(() => {
+            const preview = resolveCaptionStyle('beast', colors)
+            const pill = resolveCaptionStyle('pill', colors)
+            return (
+              <div className="flex flex-wrap items-center gap-4">
+                <span
+                  className="text-sm font-bold"
+                  style={{ color: preview.textColor, fontFamily: `'${preview.fontFamily}', sans-serif` }}
+                >
+                  SO I{' '}
+                  <span style={{ color: preview.highlightColor }}>SAID</span>
+                </span>
+                <span
+                  className="rounded px-1.5 py-0.5 text-sm font-bold"
+                  style={{
+                    color: pill.highlightColor,
+                    backgroundColor: pill.highlightBoxColor ?? 'transparent',
+                    fontFamily: `'${pill.fontFamily}', sans-serif`
+                  }}
+                >
+                  SAID
+                </span>
+              </div>
+            )
+          })()}
+        </div>
+
+        <button
+          onClick={() => saveColors({ ...DEFAULT_BRAND_COLORS, enabled: colors.enabled })}
+          className="mt-3 text-[11px] text-zinc-500 transition hover:text-zinc-300"
+        >
+          Reset colours to ClipForge defaults
+        </button>
+      </div>
+
+      <p className="mt-4 text-xs leading-relaxed text-zinc-500">
         Overlay your logo or watermark on every clip — shown in the preview and burned into
         exports, underneath the captions.
       </p>
@@ -417,6 +530,59 @@ function BrandingSection(): React.JSX.Element {
           </div>
         </>
       )}
+    </div>
+  )
+}
+
+function ColorField({
+  label,
+  value,
+  pickerFallback = '#FFFFFF',
+  placeholder,
+  onChange,
+  onClear
+}: {
+  label: string
+  value: string
+  pickerFallback?: string
+  placeholder?: string
+  onChange: (hex: string) => void
+  onClear?: () => void
+}): React.JSX.Element {
+  const picker = /^#[0-9A-Fa-f]{6}$/.test(value) ? value : pickerFallback
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <span className="text-[11px] text-zinc-500">{label}</span>
+        {onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-[10px] text-zinc-600 transition hover:text-zinc-300"
+          >
+            Use preset
+          </button>
+        )}
+      </div>
+      <div className="flex items-center gap-2 rounded-lg border border-surface-600 bg-surface-900 px-2 py-1.5">
+        <input
+          type="color"
+          value={picker}
+          onChange={(e) => onChange(e.target.value.toUpperCase())}
+          className="h-7 w-7 shrink-0 cursor-pointer rounded border-0 bg-transparent p-0"
+        />
+        <input
+          type="text"
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => {
+            const next = e.target.value.trim()
+            if (/^#[0-9A-Fa-f]{6}$/.test(next)) onChange(next.toUpperCase())
+          }}
+          className="min-w-0 flex-1 bg-transparent font-mono text-[11px] text-zinc-300 placeholder:text-zinc-600 focus:outline-none"
+        />
+      </div>
     </div>
   )
 }

--- a/src/shared/captionStyles.ts
+++ b/src/shared/captionStyles.ts
@@ -1,3 +1,5 @@
+import type { BrandColors } from './types'
+
 /**
  * Caption style presets, shared by the renderer (live preview) and the main
  * process (ASS subtitle generation for burn-in).
@@ -225,6 +227,55 @@ export const CAPTION_STYLES: CaptionStyle[] = [
 
 export const DEFAULT_CAPTION_STYLE_ID = 'beast'
 
+export const DEFAULT_BRAND_COLORS: BrandColors = {
+  enabled: false,
+  primaryColor: '#A855F7',
+  secondaryColor: '#FFFFFF',
+  textColor: null,
+  outlineColor: null,
+  hookTextColor: '#FFFFFF',
+  hookBackgroundColor: '#000000'
+}
+
 export function getCaptionStyle(id: string): CaptionStyle {
   return CAPTION_STYLES.find((s) => s.id === id) ?? CAPTION_STYLES[0]
+}
+
+/** Merge app-wide brand colours onto a caption preset (and optional font override). */
+export function resolveCaptionStyle(
+  id: string,
+  brandColors?: BrandColors | null,
+  fontFamily?: string | null
+): CaptionStyle {
+  const preset = getCaptionStyle(id)
+  let style: CaptionStyle = fontFamily ? { ...preset, fontFamily } : { ...preset }
+
+  if (!brandColors?.enabled) return style
+
+  if (preset.highlightBoxColor !== null) {
+    style = {
+      ...style,
+      highlightBoxColor: brandColors.primaryColor,
+      highlightColor: brandColors.secondaryColor
+    }
+  } else {
+    style = { ...style, highlightColor: brandColors.primaryColor }
+  }
+  if (brandColors.textColor) {
+    style = { ...style, textColor: brandColors.textColor }
+  }
+  if (brandColors.outlineColor) {
+    style = { ...style, outlineColor: brandColors.outlineColor }
+  }
+  return style
+}
+
+/** Convert "#RRGGBB" to an rgba() string for CSS previews. */
+export function hexToRgba(hex: string, alpha: number): string {
+  const clean = hex.replace('#', '')
+  if (clean.length !== 6) return `rgba(0,0,0,${alpha})`
+  const r = parseInt(clean.slice(0, 2), 16)
+  const g = parseInt(clean.slice(2, 4), 16)
+  const b = parseInt(clean.slice(4, 6), 16)
+  return `rgba(${r},${g},${b},${alpha})`
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -199,6 +199,23 @@ export type QualityPreference = 'draft' | 'standard' | 'high'
 /** Corner where the branding watermark is composited. */
 export type WatermarkPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
 
+/**
+ * Saved brand palette applied as defaults across caption styles when enabled.
+ * Primary is the main pop colour (word highlight or pill fill); secondary is
+ * the active-word text on pill/box presets.
+ */
+export interface BrandColors {
+  enabled: boolean
+  primaryColor: string
+  secondaryColor: string
+  /** When set, overrides the preset base caption text colour. */
+  textColor: string | null
+  /** When set, overrides the preset caption outline colour. */
+  outlineColor: string | null
+  hookTextColor: string
+  hookBackgroundColor: string
+}
+
 /** App-wide branding applied to the preview and burned into exports. */
 export interface BrandingSettings {
   enabled: boolean
@@ -209,6 +226,7 @@ export interface BrandingSettings {
   opacity: number
   /** Watermark width as a fraction of the output video width. */
   scale: number
+  colors: BrandColors
 }
 
 /**

--- a/tests/brandColors.test.ts
+++ b/tests/brandColors.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { buildAss } from '../src/main/pipeline/captions'
+import { DEFAULT_BRAND_COLORS, getCaptionStyle, resolveCaptionStyle } from '../src/shared/captionStyles'
+import { makeTranscript } from './helpers'
+
+describe('resolveCaptionStyle', () => {
+  it('returns the preset unchanged when brand colours are disabled', () => {
+    const style = resolveCaptionStyle('beast', DEFAULT_BRAND_COLORS)
+    expect(style.highlightColor).toBe('#FFD400')
+  })
+
+  it('overrides highlight colour on text-highlight styles when enabled', () => {
+    const style = resolveCaptionStyle('beast', {
+      ...DEFAULT_BRAND_COLORS,
+      enabled: true,
+      primaryColor: '#A855F7'
+    })
+    expect(style.highlightColor).toBe('#A855F7')
+  })
+
+  it('maps primary/secondary onto pill styles when enabled', () => {
+    const style = resolveCaptionStyle('pill', {
+      ...DEFAULT_BRAND_COLORS,
+      enabled: true,
+      primaryColor: '#A855F7',
+      secondaryColor: '#FFFFFF'
+    })
+    expect(style.highlightBoxColor).toBe('#A855F7')
+    expect(style.highlightColor).toBe('#FFFFFF')
+  })
+
+  it('honours optional text and outline overrides', () => {
+    const style = resolveCaptionStyle('beast', {
+      ...DEFAULT_BRAND_COLORS,
+      enabled: true,
+      textColor: '#E4E4E7',
+      outlineColor: '#18181B'
+    })
+    expect(style.textColor).toBe('#E4E4E7')
+    expect(style.outlineColor).toBe('#18181B')
+  })
+
+  it('applies a custom font family override', () => {
+    const preset = getCaptionStyle('beast')
+    const style = resolveCaptionStyle('beast', null, 'My Brand Font')
+    expect(style.fontFamily).toBe('My Brand Font')
+    expect(style.highlightColor).toBe(preset.highlightColor)
+  })
+})
+
+describe('buildAss brand colours', () => {
+  const transcript = makeTranscript(['hello world'], { wordSec: 0.5, gapSec: 0.1 })
+  const base = {
+    styleId: 'beast',
+    width: 1080,
+    height: 1920,
+    clipStart: 0,
+    clipEnd: transcript.durationSec
+  }
+
+  it('uses the brand highlight colour in ASS output when enabled', () => {
+    const ass = buildAss(transcript, {
+      ...base,
+      brandColors: {
+        ...DEFAULT_BRAND_COLORS,
+        enabled: true,
+        primaryColor: '#A855F7'
+      }
+    })
+    // #A855F7 -> BGR &HF755A8 (inline karaoke tag)
+    expect(ass).toContain('&HF755A8&')
+    expect(ass).not.toContain('&H00D4FF&')
+  })
+})

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildFilterGraph } from '../src/main/pipeline/render'
-import { DEFAULT_CAPTION_STYLE_ID } from '@shared/captionStyles'
+import { DEFAULT_BRAND_COLORS, DEFAULT_CAPTION_STYLE_ID } from '@shared/captionStyles'
 import type { BrandingSettings, Clip, VideoInfo } from '@shared/types'
 
 function makeClip(start = 0, end = 30): Clip {
@@ -49,7 +49,8 @@ const branding: BrandingSettings = {
   imagePath: '/tmp/logo.png',
   position: 'bottom-right',
   opacity: 0.8,
-  scale: 0.16
+  scale: 0.16,
+  colors: DEFAULT_BRAND_COLORS
 }
 
 describe('buildFilterGraph', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds persistent **brand colour** controls in Settings so your palette becomes the default across every caption style — in the live preview, editor swatches, and exported videos.

## What's new

**Settings → Branding → Brand colours**
- Toggle **Use brand colours on captions**
- **Primary** — word highlight on text styles (Beast, Karaoke, …) or pill fill on box styles (Pill, Hormozi, …)
- **Secondary** — active-word text on pill/box styles
- **Caption text / Outline** — optional overrides (or “Use preset” to keep each style’s default)
- **Hook text / Hook background** — colours for the title card overlay
- Live preview swatch + reset to ClipForge defaults

## How it works

Brand colours are saved in `settings.json` under `branding.colors` and merged onto caption presets via `resolveCaptionStyle()` in:
- Preview player captions + hook card
- Editor caption style picker
- ASS subtitle generation on export

Watermark/logo settings are unchanged.

## How to verify

1. Open **Settings → Branding**
2. Enable brand colours and set primary to your purple (`#A855F7`)
3. Open a clip in the editor — caption swatches and preview should use your colours
4. Export a clip and confirm the burned-in captions match

`npm test` — 164 tests passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f487c0bb-63df-429c-a224-db383bdc836d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f487c0bb-63df-429c-a224-db383bdc836d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

