### PR TITLE
Default hook trimming and hook text off; add setup toggle

### DIFF
--- a/scripts/test-e2e.ts
+++ b/scripts/test-e2e.ts
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
     API_KEY,
     'gpt-5.4-mini',
     transcript,
-    { prompt: '', clipLength: 'short', broll: false },
+    { prompt: '', clipLength: 'short', broll: false, hookFirst: false },
     info.durationSec
   )
   assert.ok(clips.length >= 1, 'no clips detected')

--- a/scripts/test-youtube.ts
+++ b/scripts/test-youtube.ts
@@ -112,7 +112,7 @@ async function main(): Promise<void> {
   console.log(`   "${transcript.segments.map((s) => s.text).join(' ').slice(0, 120)}…"`)
 
   console.log('6. Detecting highlights…')
-  const clips = await detectHighlights(apiKey, 'gpt-5.4-mini', transcript, { prompt: '', clipLength: 'short', broll: false }, info.durationSec)
+  const clips = await detectHighlights(apiKey, 'gpt-5.4-mini', transcript, { prompt: '', clipLength: 'short', broll: false, hookFirst: false }, info.durationSec)
   assert.ok(clips.length >= 1, 'no clips found')
   for (const c of clips) {
     const dur = c.suggestedEnd - c.suggestedStart

--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -534,10 +534,11 @@ export async function detectHighlights(
       ? first
       : await requestHighlights(apiKey, model, transcript, options, videoDurationSec, true, signal)
   const refined = await refineClipEndings(apiKey, model, transcript, clips, videoDurationSec, signal)
-  // Then trim any leading setup so each clip opens on its hook.
-  const hooked = await refineClipStarts(apiKey, model, transcript, refined, signal)
+  const trimmed = options.hookFirst
+    ? await refineClipStarts(apiKey, model, transcript, refined, signal)
+    : refined
   // Refinement can pull two clips onto the same landing beat; dedupe again.
-  return dedupeClips(hooked)
+  return dedupeClips(trimmed)
 }
 
 async function requestHighlights(
@@ -669,7 +670,7 @@ async function requestHighlights(
         focusX: 0.5,
         captionsEnabled: true,
         captionStyleId: DEFAULT_CAPTION_STYLE_ID,
-        showTitle: true,
+        showTitle: false,
         start,
         end
       }

--- a/src/renderer/src/components/HomeScreen.tsx
+++ b/src/renderer/src/components/HomeScreen.tsx
@@ -9,7 +9,8 @@ import {
   Trash2,
   AlertTriangle,
   Wand2,
-  Clock
+  Clock,
+  Zap
 } from 'lucide-react'
 import { useStore } from '../store'
 import { formatDuration, formatBytes } from '../lib/format'
@@ -272,6 +273,8 @@ function SetupPanel(): React.JSX.Element {
   const [clipLength, setClipLength] = useState<ClipLengthPreference>('auto')
   // Off by default: B-roll costs extra LLM/image calls and splits opinion.
   const [broll, setBroll] = useState(false)
+  // Off by default: hook-first trimming rewrites clip starts with an extra LLM pass.
+  const [hookFirst, setHookFirst] = useState(false)
 
   const needsKey = settings !== null && !settings.hasApiKey
 
@@ -373,6 +376,32 @@ function SetupPanel(): React.JSX.Element {
           </div>
 
           <div className="rounded-2xl border border-surface-700 bg-surface-900 p-5">
+            <button
+              onClick={() => setHookFirst(!hookFirst)}
+              className="flex w-full items-center justify-between gap-4 text-left"
+            >
+              <span className="min-w-0">
+                <span className="flex items-center gap-2 text-sm font-semibold">
+                  <Zap size={15} className="text-accent-400" />
+                  Open on the hook
+                </span>
+                <span className="mt-1 block text-xs leading-relaxed text-zinc-500">
+                  Finds each clip&apos;s hook line and trims the start so the video opens on that
+                  moment instead of throat-clearing. You can still turn on the hook title card per
+                  clip in the editor.
+                </span>
+              </span>
+              <span
+                className={`relative h-5 w-9 shrink-0 rounded-full transition ${hookFirst ? 'bg-zinc-100' : 'bg-surface-600'}`}
+              >
+                <span
+                  className={`absolute top-0.5 h-4 w-4 rounded-full transition-all ${hookFirst ? 'left-[18px] bg-zinc-900' : 'left-0.5 bg-white'}`}
+                />
+              </span>
+            </button>
+          </div>
+
+          <div className="rounded-2xl border border-surface-700 bg-surface-900 p-5">
             <label className="flex items-center gap-2 text-sm font-semibold">
               <Clock size={15} className="text-accent-400" />
               Preferred clip length
@@ -412,7 +441,7 @@ function SetupPanel(): React.JSX.Element {
           ) : (
             <div>
               <button
-                onClick={() => void analyze({ prompt, clipLength, broll })}
+                onClick={() => void analyze({ prompt, clipLength, broll, hookFirst })}
                 className="flex w-full items-center justify-center gap-2 rounded-xl bg-zinc-100 px-5 py-3.5 text-sm font-semibold text-zinc-900 shadow-lg shadow-black/40 transition hover:bg-white"
               >
                 <Sparkles size={17} />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -175,6 +175,8 @@ export interface AnalyzeOptions {
   clipLength: ClipLengthPreference
   /** Generate AI B-roll image inserts timed to spoken keywords. */
   broll: boolean
+  /** Trim each clip's start so it opens on its hook line instead of setup. */
+  hookFirst: boolean
 }
 
 export type ClipLengthPreference = 'auto' | 'short' | 'medium' | 'long'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Hook-first trimming** (`refineClipStarts`) is now **off by default** and exposed as an **Open on the hook** toggle on the setup screen (same pattern as B-roll).
- **Hook title card** (`showTitle`) is now **off by default** for newly generated clips. Users can still enable it per clip in the editor.

## Changes

- `AnalyzeOptions.hookFirst` — gates the extra LLM pass that trims clip starts to the hook line
- `highlights.ts` — `showTitle: false` for new clips
- `HomeScreen` — new toggle with description

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (167 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f487c0bb-63df-429c-a224-db383bdc836d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f487c0bb-63df-429c-a224-db383bdc836d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

