### PR TITLE
Fix WorkVivo posting and add brand-voiced captions + settings page

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -308,7 +308,13 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(
     'workvivo:postClip',
-    async (event, projectId: string, clipId: string, spaceId: string) => {
+    async (
+      event,
+      projectId: string,
+      clipId: string,
+      spaceId: string,
+      workvivoCaption?: string | null
+    ) => {
       const cfg = getWorkvivoConfig()
       if (!cfg) {
         throw new Error(
@@ -330,6 +336,7 @@ export function registerIpcHandlers(): void {
       if (runningWorkvivoPosts.has(clipId)) throw new Error('This clip is already being posted.')
 
       const text = (
+        (typeof workvivoCaption === 'string' ? workvivoCaption.trim() : '') ||
         clip.workvivoCaption?.trim() ||
         clip.caption?.trim() ||
         clip.title ||

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { existsSync } from 'node:fs'
-import { copyFile, mkdir, rm } from 'node:fs/promises'
+import { copyFile, mkdir, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import { basename, extname, join } from 'node:path'
@@ -14,11 +14,18 @@ import type {
 import { VIDEO_EXTENSIONS } from '@shared/video'
 import { analyzeProject, createProject, createProjectFromUrl } from './pipeline'
 import { downloadGpuFfmpeg } from './pipeline/encoders'
-import { probeVideo } from './pipeline/ffmpeg'
+import { compressToTargetSize, probeVideo } from './pipeline/ffmpeg'
 import { getTimeline } from './pipeline/timeline'
 import { renderClip } from './pipeline/render'
 import { generateSocialCaption } from './pipeline/socialCaption'
-import { listSpaces, postClipToSpace, testConnection } from './pipeline/workvivo'
+import { generateWorkvivoCaption } from './pipeline/workvivoCaption'
+import {
+  findUserByEmail,
+  listSpaces,
+  postClipToSpace,
+  testConnection,
+  WorkvivoError
+} from './pipeline/workvivo'
 import { addCustomFonts, listCustomFonts, removeCustomFont, renderFontsDir } from './fonts'
 import { clearImportCookiesFile, installImportCookiesFile } from './cookies'
 import { checkForUpdates, downloadUpdate, installUpdate, updateFromSource } from './updates'
@@ -28,6 +35,7 @@ import { deleteProject, listProjects, loadProject, saveProject } from './project
 import {
   getApiKey,
   getBrandingSettings,
+  getBrandVoiceSettings,
   getExportPreferences,
   getModelPreferences,
   getSettings,
@@ -42,6 +50,20 @@ const runningWorkvivoPosts = new Map<string, AbortController>()
 export const ANALYSIS_CANCELLED_MESSAGE = 'Analysis cancelled'
 export const EXPORT_CANCELLED_MESSAGE = 'Export cancelled'
 export const WORKVIVO_POST_CANCELLED_MESSAGE = 'WorkVivo post cancelled'
+
+const MB = 1024 * 1024
+/**
+ * WorkVivo's Customer API rejects large inline uploads with HTTP 413, well below
+ * the size its web uploader accepts (that path uses chunked upload; the API does
+ * not). The exact cap is undocumented, so we pre-shrink very large renders and,
+ * on a 413, retry with progressively smaller targets until it fits or we give up.
+ */
+const WORKVIVO_PRESHRINK_BYTES = 64 * MB
+const WORKVIVO_FIT_TARGETS: Array<{ bytes: number; maxHeight?: number }> = [
+  { bytes: 40 * MB },
+  { bytes: 20 * MB, maxHeight: 720 },
+  { bytes: 10 * MB, maxHeight: 720 }
+]
 
 /** How far apart durations may be for a relinked file to count as the same video. */
 const RELINK_DURATION_TOLERANCE_SEC = 2
@@ -243,6 +265,24 @@ export function registerIpcHandlers(): void {
     return project
   })
 
+  ipcMain.handle('workvivo:generateCaption', async (_e, projectId: string, clipId: string) => {
+    const project = await loadProject(projectId)
+    const clip = project.clips.find((c) => c.id === clipId)
+    if (!clip) throw new Error('Clip not found')
+    const apiKey = getApiKey()
+    if (!apiKey) throw new Error('Add your OpenAI API key in Settings first.')
+    const caption = await generateWorkvivoCaption(
+      apiKey,
+      getModelPreferences().analysisModel,
+      clip,
+      project.transcript,
+      getBrandVoiceSettings()
+    )
+    clip.workvivoCaption = caption
+    await saveProject(project)
+    return project
+  })
+
   ipcMain.handle('workvivo:testConnection', async () => {
     const cfg = getWorkvivoConfig()
     if (!cfg) {
@@ -257,6 +297,15 @@ export function registerIpcHandlers(): void {
     return listSpaces(cfg.request)
   })
 
+  ipcMain.handle('workvivo:findUser', async (_e, email: string) => {
+    const cfg = getWorkvivoConfig()
+    if (!cfg) {
+      throw new Error('Add your WorkVivo URL, Organisation ID and API key first.')
+    }
+    if (!email.trim()) throw new Error('Enter an email address to look up.')
+    return findUserByEmail(cfg.request, email.trim())
+  })
+
   ipcMain.handle(
     'workvivo:postClip',
     async (event, projectId: string, clipId: string, spaceId: string) => {
@@ -267,6 +316,11 @@ export function registerIpcHandlers(): void {
         )
       }
       if (!spaceId) throw new Error('Choose a WorkVivo space to post to.')
+      if (!cfg.postAsUserId) {
+        throw new Error(
+          'Set the “Post as” WorkVivo user ID in Settings → WorkVivo first — WorkVivo requires every post to be attributed to a user.'
+        )
+      }
       const project = await loadProject(projectId)
       const clip = project.clips.find((c) => c.id === clipId)
       if (!clip) throw new Error('Clip not found')
@@ -275,7 +329,12 @@ export function registerIpcHandlers(): void {
       }
       if (runningWorkvivoPosts.has(clipId)) throw new Error('This clip is already being posted.')
 
-      const text = (clip.caption?.trim() || clip.title || '').trim()
+      const text = (
+        clip.workvivoCaption?.trim() ||
+        clip.caption?.trim() ||
+        clip.title ||
+        ''
+      ).trim()
       const prefs = getExportPreferences()
       const branding = getBrandingSettings()
       const controller = new AbortController()
@@ -283,6 +342,8 @@ export function registerIpcHandlers(): void {
       const dir = join(tmpdir(), 'clipforge', 'workvivo')
       await mkdir(dir, { recursive: true })
       const outputPath = join(dir, `${clipId}-${randomUUID()}.mp4`)
+      // Temp files created while shrinking to fit WorkVivo's upload cap.
+      const fitPaths: string[] = []
       const send = (progress: number, message: string): void => {
         if (!event.sender.isDestroyed()) {
           event.sender.send('workvivo:progress', { clipId, progress, message })
@@ -306,16 +367,56 @@ export function registerIpcHandlers(): void {
           // Rendering is the first 80% of the job; upload is the rest.
           onProgress: (fraction) => send(fraction * 0.8, 'Rendering clip…')
         })
-        send(0.85, 'Uploading to WorkVivo…')
-        const result = await postClipToSpace(cfg.request, {
-          videoPath: outputPath,
-          text,
-          spaceId,
-          postAsUserId: cfg.postAsUserId || undefined,
-          signal: controller.signal
-        })
-        send(1, 'Posted to WorkVivo')
-        return result
+        // Upload, shrinking to fit WorkVivo's request-size cap when needed.
+        let uploadPath = outputPath
+        const rendered = await stat(outputPath)
+        if (rendered.size > WORKVIVO_PRESHRINK_BYTES) {
+          send(0.82, 'Compressing for WorkVivo…')
+          const fit = join(dir, `${clipId}-fit-0.mp4`)
+          fitPaths.push(fit)
+          await compressToTargetSize(outputPath, fit, WORKVIVO_PRESHRINK_BYTES, {
+            signal: controller.signal,
+            onProgress: (f) => send(0.8 + f * 0.05, 'Compressing for WorkVivo…')
+          })
+          uploadPath = fit
+        }
+        for (let attempt = 0; ; attempt++) {
+          try {
+            send(0.85, 'Uploading to WorkVivo…')
+            const result = await postClipToSpace(cfg.request, {
+              videoPath: uploadPath,
+              text,
+              spaceId,
+              postAsUserId: cfg.postAsUserId || undefined,
+              signal: controller.signal
+            })
+            send(1, 'Posted to WorkVivo')
+            return result
+          } catch (uploadErr) {
+            const tooLarge = uploadErr instanceof WorkvivoError && uploadErr.status === 413
+            if (!tooLarge || attempt >= WORKVIVO_FIT_TARGETS.length) {
+              if (tooLarge) {
+                throw new Error(
+                  'This clip is too large for WorkVivo even after compression. Try a shorter clip or lower the export quality.',
+                  { cause: uploadErr }
+                )
+              }
+              throw uploadErr
+            }
+            // Re-compress from the original render (not the previous attempt) to
+            // avoid stacking generation loss, aiming at the next smaller target.
+            const target = WORKVIVO_FIT_TARGETS[attempt]
+            const fit = join(dir, `${clipId}-fit-${attempt + 1}.mp4`)
+            fitPaths.push(fit)
+            send(0.82, 'Video too large — compressing for WorkVivo…')
+            await compressToTargetSize(outputPath, fit, target.bytes, {
+              maxHeight: target.maxHeight,
+              signal: controller.signal,
+              onProgress: (f) => send(0.8 + f * 0.05, 'Compressing for WorkVivo…')
+            })
+            uploadPath = fit
+          }
+        }
       } catch (err) {
         if (controller.signal.aborted) {
           throw new Error(WORKVIVO_POST_CANCELLED_MESSAGE, { cause: err })
@@ -323,7 +424,9 @@ export function registerIpcHandlers(): void {
         throw err
       } finally {
         runningWorkvivoPosts.delete(clipId)
-        await rm(outputPath, { force: true }).catch(() => undefined)
+        await Promise.all(
+          [outputPath, ...fitPaths].map((p) => rm(p, { force: true }).catch(() => undefined))
+        )
       }
     }
   )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -335,13 +335,10 @@ export function registerIpcHandlers(): void {
       }
       if (runningWorkvivoPosts.has(clipId)) throw new Error('This clip is already being posted.')
 
-      const text = (
-        (typeof workvivoCaption === 'string' ? workvivoCaption.trim() : '') ||
-        clip.workvivoCaption?.trim() ||
-        clip.caption?.trim() ||
-        clip.title ||
-        ''
-      ).trim()
+      const text =
+        typeof workvivoCaption === 'string'
+          ? workvivoCaption.trim()
+          : (clip.workvivoCaption?.trim() || clip.caption?.trim() || clip.title || '').trim()
       const prefs = getExportPreferences()
       const branding = getBrandingSettings()
       const controller = new AbortController()

--- a/src/main/pipeline/ffmpeg.ts
+++ b/src/main/pipeline/ffmpeg.ts
@@ -216,6 +216,48 @@ export async function extractAudioChunks(
   return chunks
 }
 
+/**
+ * Re-encode a video to land under `targetBytes`, for uploading to services that
+ * cap request body size (e.g. WorkVivo's Customer API, which rejects large
+ * inline multipart uploads with HTTP 413). Single-pass H.264 with an average
+ * bitrate derived from the clip's duration and a peak cap, optionally
+ * downscaling to `maxHeight`. It is not byte-exact, so it aims a little under
+ * the target and callers should still be ready to retry with a smaller target.
+ * Uses the bundled CPU encoder so it works without a GPU build.
+ */
+export async function compressToTargetSize(
+  inputPath: string,
+  outputPath: string,
+  targetBytes: number,
+  opts: { maxHeight?: number; onProgress?: (fraction: number) => void; signal?: AbortSignal } = {}
+): Promise<void> {
+  const info = await probeVideo(inputPath)
+  const audioKbps = 128
+  // Aim under the target to leave room for multipart/form overhead and VBR drift.
+  const budgetKbits = (targetBytes * 8 * 0.9) / 1000
+  const totalKbps = Math.max(1, Math.floor(budgetKbits / info.durationSec))
+  const videoKbps = Math.max(200, totalKbps - audioKbps)
+  const scale = opts.maxHeight ? ['-vf', `scale=-2:'min(${opts.maxHeight},ih)'`] : []
+  await runFfmpeg(
+    [
+      '-i', inputPath,
+      ...scale,
+      '-c:v', 'libx264', '-preset', 'veryfast',
+      '-b:v', `${videoKbps}k`,
+      '-maxrate', `${Math.floor(videoKbps * 1.35)}k`,
+      '-bufsize', `${videoKbps * 2}k`,
+      '-pix_fmt', 'yuv420p',
+      '-c:a', 'aac', '-b:a', `${audioKbps}k`,
+      '-movflags', '+faststart',
+      outputPath
+    ],
+    {
+      onProgress: (t) => opts.onProgress?.(Math.min(1, t / info.durationSec)),
+      signal: opts.signal
+    }
+  )
+}
+
 /** Grab a single frame as a JPEG thumbnail. */
 export async function extractThumbnail(
   videoPath: string,

--- a/src/main/pipeline/workvivo.ts
+++ b/src/main/pipeline/workvivo.ts
@@ -5,33 +5,45 @@ import type { WorkvivoPostResult, WorkvivoSpace, WorkvivoTestResult } from '@sha
 /**
  * Minimal WorkVivo Customer API client using Node's built-in fetch (no SDK).
  *
- * Auth model (confirmed against WorkVivo's docs and Zoom's own
- * `zoom/workvivo-zoom-integration`): every request carries a Bearer token plus
- * a `Workvivo-Id` header (the organisation id), against `<org-url>/api/v1`.
- * This is an org-level app token, not the user's interactive SSO login, so
- * posts are attributed to a configured identity (`user_id`) rather than
- * whoever clicks.
+ * Contract verified against WorkVivo's official API spec (the developer portal
+ * is a published Postman collection) and corroborated by Zoom's own
+ * `zoom/workvivo-zoom-integration`.
+ *
+ * Host: the Customer API is served from a central, region-specific host,
+ * `https://api.workvivo.<region>/v1`, NOT the tenant's own web subdomain. Region
+ * is encoded in the tenant TLD: `*.workvivo.com` (EU/global) → api.workvivo.com,
+ * `*.workvivo.us` (US) → api.workvivo.us. See `deriveWorkvivoApiBase`.
+ *
+ * Auth: every request carries a Bearer token plus a `Workvivo-Id` header (the
+ * organisation id). This is an org-level app token, not the user's interactive
+ * SSO login, so posts are attributed to a configured identity (`user_id`)
+ * rather than whoever clicks.
  *
  * Endpoints:
- * - `GET /spaces` — list spaces (used to power the picker + validate the
- *   connection). Confirmed shape: `{ data: [{ id, name }] }`.
- * - `POST /updates` — create a feed post targeted at a space, as
- *   `multipart/form-data` with `text`, `space_id`, an optional `user_id`, and a
- *   `video` file. The multipart video-upload pattern is confirmed from Zoom's
- *   integration (which uses the sibling `/kudos` endpoint the same way); the
- *   exact update-post endpoint/field names are centralised below so they are
- *   trivial to adjust against developer.workvivo.com if an org's tenant differs.
+ * - `GET /spaces?skip=&take=` — list spaces (powers the picker + validates the
+ *   connection). Shape: `{ data: [{ id, name, … }] }`.
+ * - `POST /updates` ("Create an update") — create a feed post targeted at a
+ *   space, as `multipart/form-data`. Required fields: `text`, `created_at`
+ *   (`YYYY-MM-DDTHH:MM:SSZ` UTC), and a `user_id` (or `user_external_id`) to
+ *   attribute the post to. A space is targeted via the audience array:
+ *   `audience[type]=spaces` and `audience[spaces][0]=<space id>`. The `video`
+ *   file is attached the same way; WorkVivo transcodes it, so there is a delay
+ *   before it appears on the feed. Success is `201` with `{ data: { id, … } }`.
  */
 
 /** Feed-post endpoint and its field names, kept in one place (see file header). */
 const UPDATES_ENDPOINT = 'updates'
 const FIELD_TEXT = 'text'
-const FIELD_SPACE_ID = 'space_id'
+const FIELD_CREATED_AT = 'created_at'
 const FIELD_USER_ID = 'user_id'
 const FIELD_VIDEO = 'video'
+const FIELD_AUDIENCE_TYPE = 'audience[type]'
+const AUDIENCE_TYPE_SPACES = 'spaces'
+/** WorkVivo targets an audience via an indexed array, e.g. `audience[spaces][0]`. */
+const fieldAudienceSpace = (index: number): string => `audience[spaces][${index}]`
 
 export interface WorkvivoRequestConfig {
-  /** Fully-qualified API base, e.g. https://acme.workvivo.com/api/v1. */
+  /** Fully-qualified API base, e.g. https://api.workvivo.com/v1. */
   apiBase: string
   /** Organisation id sent as the `Workvivo-Id` header. */
   companyId: string
@@ -50,10 +62,15 @@ export class WorkvivoError extends Error {
 }
 
 /**
- * Derive the WorkVivo API base URL from an organisation's WorkVivo address.
- * Accepts `https://acme.workvivo.com`, a bare `acme.workvivo.us`, or a URL that
- * already includes a path — always returning `<origin>/api/v1`. Returns null
- * when the value is not a usable host. Exported for tests.
+ * Derive the WorkVivo Customer API base URL from an organisation's WorkVivo
+ * address. The API is NOT served from the tenant's own web subdomain; it lives
+ * on a central, region-specific host `https://api.workvivo.<region>/v1`, where
+ * region is taken from the tenant TLD (`*.workvivo.com` → com, `*.workvivo.us`
+ * → us). So `https://acme.workvivo.com` → `https://api.workvivo.com/v1`.
+ *
+ * Accepts a full URL or a bare host, with or without a path. Anything that is
+ * not a WorkVivo host defaults to the `.com` (EU/global) region. Returns null
+ * only when the value is not a usable host. Exported for tests.
  */
 export function deriveWorkvivoApiBase(url: string | undefined): string | null {
   const raw = url?.trim()
@@ -61,8 +78,10 @@ export function deriveWorkvivoApiBase(url: string | undefined): string | null {
   const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`
   try {
     const u = new URL(withScheme)
-    if (!u.hostname.includes('.')) return null
-    return `${u.origin}/api/v1`
+    const host = u.hostname.toLowerCase()
+    if (!host.includes('.')) return null
+    const region = host.match(/workvivo\.(com|us|io)$/)?.[1] ?? 'com'
+    return `https://api.workvivo.${region}/v1`
   } catch {
     return null
   }
@@ -93,14 +112,20 @@ async function raiseForStatus(res: Response, context: string): Promise<never> {
   }
   if (res.status === 403) {
     throw new WorkvivoError(
-      'WorkVivo denied the request — the token is missing the required scope (spaces:read / posting write).',
+      `WorkVivo denied the request (HTTP 403)${detail ? `: ${detail}` : ''}. The API token most likely lacks permission to create posts — ask your WorkVivo admin to grant it write/create access for updates (feed posts).`,
       403
     )
   }
   if (res.status === 404) {
     throw new WorkvivoError(
-      `WorkVivo endpoint not found (HTTP 404). Check the WorkVivo URL and region (.com vs .us).`,
+      `WorkVivo endpoint not found (HTTP 404). This usually means the wrong region — check your WorkVivo URL's domain matches your tenant (.com for EU/global, .us for US).`,
       404
+    )
+  }
+  if (res.status === 413) {
+    throw new WorkvivoError(
+      `WorkVivo rejected the upload as too large (HTTP 413). The video exceeds the API's request size limit.`,
+      413
     )
   }
   throw new WorkvivoError(`${context} failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`, res.status)
@@ -125,7 +150,7 @@ export async function listSpaces(
   config: WorkvivoRequestConfig,
   signal?: AbortSignal
 ): Promise<WorkvivoSpace[]> {
-  const res = await fetch(`${config.apiBase}/spaces?per_page=200`, {
+  const res = await fetch(`${config.apiBase}/spaces?skip=0&take=100`, {
     method: 'GET',
     headers: authHeaders(config),
     signal
@@ -137,6 +162,40 @@ export async function listSpaces(
     .filter((s): s is WorkvivoSpace => s !== null)
   spaces.sort((a, b) => a.name.localeCompare(b.name))
   return spaces
+}
+
+export interface WorkvivoUser {
+  id: string
+  name: string
+}
+
+/**
+ * Resolve a WorkVivo user id from an email address, to populate the "Post as"
+ * setting (WorkVivo requires posts to be attributed to a user). Uses the
+ * documented `GET /users/by-email/:email` endpoint.
+ */
+export async function findUserByEmail(
+  config: WorkvivoRequestConfig,
+  email: string,
+  signal?: AbortSignal
+): Promise<WorkvivoUser> {
+  const res = await fetch(`${config.apiBase}/users/by-email/${encodeURIComponent(email)}`, {
+    method: 'GET',
+    headers: authHeaders(config),
+    signal
+  })
+  if (res.status === 404) {
+    throw new WorkvivoError('No WorkVivo user found with that email address.', 404)
+  }
+  if (!res.ok) await raiseForStatus(res, 'Looking up WorkVivo user')
+  const body = (await res.json()) as {
+    data?: { id?: string | number; name?: string; display_name?: string }
+  }
+  const user = body.data
+  if (!user || user.id === undefined || user.id === null) {
+    throw new WorkvivoError('No WorkVivo user found with that email address.')
+  }
+  return { id: String(user.id), name: user.name ?? user.display_name ?? String(user.id) }
 }
 
 /** Validate the connection by listing spaces. Never throws. */
@@ -173,9 +232,18 @@ export interface PostClipOptions {
   text: string
   /** Target space id. */
   spaceId: string
-  /** WorkVivo user id to attribute the post to; omitted when empty. */
+  /**
+   * WorkVivo user id to attribute the post to. WorkVivo requires this (or a
+   * user_external_id) to create an update, so an empty value will be rejected
+   * by the API; omitted from the request when empty.
+   */
   postAsUserId?: string
   signal?: AbortSignal
+}
+
+/** WorkVivo wants `created_at` as `YYYY-MM-DDTHH:MM:SSZ` (UTC, no milliseconds). */
+function workvivoTimestamp(): string {
+  return new Date().toISOString().slice(0, 19) + 'Z'
 }
 
 /** Post a rendered clip to a WorkVivo space as a feed update with the video attached. */
@@ -186,7 +254,10 @@ export async function postClipToSpace(
   const bytes = await readFile(opts.videoPath)
   const form = new FormData()
   form.append(FIELD_TEXT, opts.text)
-  form.append(FIELD_SPACE_ID, opts.spaceId)
+  form.append(FIELD_CREATED_AT, workvivoTimestamp())
+  // Target the chosen space via the audience array (audience[spaces][0]).
+  form.append(FIELD_AUDIENCE_TYPE, AUDIENCE_TYPE_SPACES)
+  form.append(fieldAudienceSpace(0), opts.spaceId)
   if (opts.postAsUserId) form.append(FIELD_USER_ID, opts.postAsUserId)
   form.append(
     FIELD_VIDEO,

--- a/src/main/pipeline/workvivo.ts
+++ b/src/main/pipeline/workvivo.ts
@@ -145,21 +145,26 @@ function toSpace(raw: RawSpace): WorkvivoSpace | null {
   return { id: String(raw.id), name }
 }
 
-/** List the spaces the token can post to (first page). */
+const SPACES_PAGE_SIZE = 100
+
+/** List all spaces the token can post to. */
 export async function listSpaces(
   config: WorkvivoRequestConfig,
   signal?: AbortSignal
 ): Promise<WorkvivoSpace[]> {
-  const res = await fetch(`${config.apiBase}/spaces?skip=0&take=100`, {
-    method: 'GET',
-    headers: authHeaders(config),
-    signal
-  })
-  if (!res.ok) await raiseForStatus(res, 'Listing WorkVivo spaces')
-  const body = (await res.json()) as { data?: RawSpace[] }
-  const spaces = (body.data ?? [])
-    .map(toSpace)
-    .filter((s): s is WorkvivoSpace => s !== null)
+  const spaces: WorkvivoSpace[] = []
+  for (let skip = 0; ; skip += SPACES_PAGE_SIZE) {
+    const res = await fetch(`${config.apiBase}/spaces?skip=${skip}&take=${SPACES_PAGE_SIZE}`, {
+      method: 'GET',
+      headers: authHeaders(config),
+      signal
+    })
+    if (!res.ok) await raiseForStatus(res, 'Listing WorkVivo spaces')
+    const body = (await res.json()) as { data?: RawSpace[] }
+    const page = body.data ?? []
+    spaces.push(...page.map(toSpace).filter((s): s is WorkvivoSpace => s !== null))
+    if (page.length < SPACES_PAGE_SIZE) break
+  }
   spaces.sort((a, b) => a.name.localeCompare(b.name))
   return spaces
 }

--- a/src/main/pipeline/workvivoCaption.ts
+++ b/src/main/pipeline/workvivoCaption.ts
@@ -1,0 +1,92 @@
+import type { BrandVoiceSettings, Clip, Transcript } from '@shared/types'
+import { wordsInRange } from '@shared/captionLayout'
+import { chatJSON } from './openai'
+
+/**
+ * Generates a caption for posting a clip to WorkVivo — an internal employee
+ * experience platform, not a public social feed. The register is colleague-to-
+ * colleague: warm, clear, and free of the hashtag spam and growth hooks that
+ * suit TikTok. Kept separate from `generateSocialCaption` for exactly that
+ * reason. Brand voice settings (name/tone/style/avoid) steer it so captions
+ * sound like the organisation rather than generic AI copy.
+ */
+
+const BASE_SYSTEM_PROMPT = `You write post captions for WorkVivo, an internal employee communications platform (a company's private social feed). Your caption introduces a short video to colleagues.
+
+Rules:
+- Write for an internal audience of coworkers, not the public. Warm, human and clear.
+- 1-3 short sentences. Lead with what the video is and why a colleague would want to watch it.
+- No hashtags. No emoji spam (0-1 emoji at most, only if it genuinely fits). No clickbait hooks, no "link in bio", no growth-hacking tricks.
+- Never invent facts, names or figures that are not in the clip.
+- If a house brand voice is provided, follow it exactly. Otherwise default to British English in a friendly, professional voice.`
+
+function brandVoiceLines(voice: BrandVoiceSettings): string {
+  const lines: string[] = []
+  if (voice.brandName.trim()) lines.push(`Brand/organisation name: ${voice.brandName.trim()}`)
+  if (voice.tone.trim()) lines.push(`Tone of voice: ${voice.tone.trim()}`)
+  if (voice.style.trim()) lines.push(`Writing style: ${voice.style.trim()}`)
+  if (voice.avoid.trim()) lines.push(`Avoid: ${voice.avoid.trim()}`)
+  return lines.join('\n')
+}
+
+interface CaptionResponse {
+  caption: string
+}
+
+const RESPONSE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['caption'],
+  properties: {
+    caption: {
+      type: 'string',
+      description: 'The complete WorkVivo post caption, ready to post'
+    }
+  }
+} as const
+
+export async function generateWorkvivoCaption(
+  apiKey: string,
+  model: string,
+  clip: Clip,
+  transcript: Transcript | null,
+  voice: BrandVoiceSettings,
+  signal?: AbortSignal
+): Promise<string> {
+  const excerpt = transcript
+    ? wordsInRange(transcript, clip.edit.start, clip.edit.end)
+        .map((w) => w.text)
+        .join(' ')
+        .slice(0, 1800)
+    : ''
+
+  const brand = brandVoiceLines(voice)
+  const systemPrompt = brand
+    ? `${BASE_SYSTEM_PROMPT}\n\nHouse brand voice (follow this):\n${brand}`
+    : BASE_SYSTEM_PROMPT
+
+  const userPrompt = [
+    `Clip title: "${clip.title}"`,
+    clip.hook ? `On-screen hook: "${clip.hook}"` : '',
+    clip.summary ? `Summary: ${clip.summary}` : '',
+    excerpt ? `Transcript of the clip:\n"${excerpt}"` : '',
+    'Write the WorkVivo caption.'
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+
+  const res = await chatJSON<CaptionResponse>(
+    apiKey,
+    model,
+    [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt }
+    ],
+    'workvivo_caption',
+    RESPONSE_SCHEMA as unknown as Record<string, unknown>,
+    signal
+  )
+  const caption = res.caption?.trim()
+  if (!caption) throw new Error('Caption generation returned an empty result')
+  return caption
+}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import type {
   AppSettings,
   BrandingSettings,
+  BrandVoiceSettings,
   BrowserCookieSource,
   EncoderPreference,
   QualityPreference,
@@ -34,6 +35,7 @@ interface StoredSettings {
   encoder: EncoderPreference
   quality: QualityPreference
   branding: BrandingSettings
+  brandVoice: BrandVoiceSettings
   importCookiesBrowser: BrowserCookieSource
   workvivo: StoredWorkvivo
 }
@@ -45,6 +47,13 @@ const DEFAULT_BRANDING: BrandingSettings = {
   opacity: 0.8,
   scale: 0.16,
   colors: DEFAULT_BRAND_COLORS
+}
+
+const DEFAULT_BRAND_VOICE: BrandVoiceSettings = {
+  brandName: '',
+  tone: '',
+  style: '',
+  avoid: ''
 }
 
 const DEFAULT_WORKVIVO: StoredWorkvivo = {
@@ -67,6 +76,7 @@ const DEFAULTS: StoredSettings = {
   encoder: 'auto',
   quality: 'standard',
   branding: DEFAULT_BRANDING,
+  brandVoice: DEFAULT_BRAND_VOICE,
   importCookiesBrowser: '',
   workvivo: DEFAULT_WORKVIVO
 }
@@ -91,6 +101,7 @@ function load(): StoredSettings {
           ...(parsed.branding ?? {}),
           colors: { ...DEFAULT_BRAND_COLORS, ...(parsed.branding?.colors ?? {}) }
         },
+        brandVoice: { ...DEFAULT_BRAND_VOICE, ...(parsed.brandVoice ?? {}) },
         workvivo: { ...DEFAULT_WORKVIVO, ...(parsed.workvivo ?? {}) }
       }
       return cache
@@ -149,6 +160,7 @@ export async function getSettings(): Promise<AppSettings> {
     quality: s.quality,
     gpu: await getGpuStatus(),
     branding: s.branding,
+    brandVoice: s.brandVoice,
     appVersion: app.getVersion(),
     importCookiesBrowser: s.importCookiesBrowser,
     hasImportCookiesFile: getImportCookiesPath() !== null,
@@ -207,6 +219,11 @@ export function getBrandingSettings(): BrandingSettings {
   return load().branding
 }
 
+/** Synchronous access to the stored brand tone-of-voice settings. */
+export function getBrandVoiceSettings(): BrandVoiceSettings {
+  return load().brandVoice
+}
+
 /** Synchronous access to the stored encoder/quality preferences. */
 export function getExportPreferences(): { encoder: EncoderPreference; quality: QualityPreference } {
   const s = load()
@@ -248,6 +265,9 @@ export async function updateSettings(update: SettingsUpdate): Promise<AppSetting
       ...b,
       ...(b.colors !== undefined ? { colors: { ...s.branding.colors, ...b.colors } } : {})
     }
+  }
+  if (update.brandVoice !== undefined) {
+    s.brandVoice = { ...s.brandVoice, ...update.brandVoice }
   }
   if (update.importCookiesBrowser !== undefined) s.importCookiesBrowser = update.importCookiesBrowser
   if (update.clearImportCookiesFile) await clearImportCookiesFile()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -55,8 +55,12 @@ const api = {
   generateCaption: (projectId: string, clipId: string): Promise<Project> =>
     ipcRenderer.invoke('clip:generateCaption', projectId, clipId),
 
+  generateWorkvivoCaption: (projectId: string, clipId: string): Promise<Project> =>
+    ipcRenderer.invoke('workvivo:generateCaption', projectId, clipId),
   testWorkvivo: (): Promise<WorkvivoTestResult> => ipcRenderer.invoke('workvivo:testConnection'),
   listWorkvivoSpaces: (): Promise<WorkvivoSpace[]> => ipcRenderer.invoke('workvivo:listSpaces'),
+  findWorkvivoUser: (email: string): Promise<{ id: string; name: string }> =>
+    ipcRenderer.invoke('workvivo:findUser', email),
   postClipToWorkvivo: (
     projectId: string,
     clipId: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -64,9 +64,10 @@ const api = {
   postClipToWorkvivo: (
     projectId: string,
     clipId: string,
-    spaceId: string
+    spaceId: string,
+    workvivoCaption?: string | null
   ): Promise<WorkvivoPostResult> =>
-    ipcRenderer.invoke('workvivo:postClip', projectId, clipId, spaceId),
+    ipcRenderer.invoke('workvivo:postClip', projectId, clipId, spaceId, workvivoCaption),
   cancelWorkvivoPost: (clipId: string): Promise<void> =>
     ipcRenderer.invoke('workvivo:cancelPost', clipId),
   onWorkvivoProgress: (cb: (p: WorkvivoPostProgress) => void): (() => void) => {

--- a/src/renderer/src/components/EditorScreen.tsx
+++ b/src/renderer/src/components/EditorScreen.tsx
@@ -581,9 +581,14 @@ function WorkvivoPostBlock({ clip }: { clip: Clip }): React.JSX.Element {
   const clear = useStore((s) => s.clearWorkvivoPost)
   const entry = useStore((s) => s.workvivoPosts[clip.id])
   const setSettingsOpen = useStore((s) => s.setSettingsOpen)
+  const updateClip = useStore((s) => s.updateClip)
+  const updateClipLocal = useStore((s) => s.updateClipLocal)
+  const genCaption = useStore((s) => s.generateWorkvivoCaption)
+  const captionBusy = useStore((s) => s.workvivoCaptionBusy[clip.id] ?? false)
   const configured = settings?.workvivo.configured ?? false
   const defaultSpaceId = settings?.workvivo.defaultSpaceId ?? ''
   const [picked, setPicked] = useState('')
+  const [captionError, setCaptionError] = useState<string | null>(null)
   // Effective selection: an explicit pick, else the configured default, else
   // the first space. Computed (not stored) so no effect has to seed it.
   const spaceId = picked || defaultSpaceId || spaces[0]?.id || ''
@@ -591,6 +596,19 @@ function WorkvivoPostBlock({ clip }: { clip: Clip }): React.JSX.Element {
   useEffect(() => {
     if (configured) void loadSpaces()
   }, [configured, loadSpaces])
+
+  const generateCaption = async (): Promise<void> => {
+    setCaptionError(null)
+    try {
+      await genCaption(clip.id)
+    } catch (err) {
+      setCaptionError(
+        err instanceof Error
+          ? err.message.replace(/^Error invoking remote method '[^']+':\s*(Error:\s*)?/, '')
+          : String(err)
+      )
+    }
+  }
 
   if (!configured) {
     return (
@@ -636,6 +654,30 @@ function WorkvivoPostBlock({ clip }: { clip: Clip }): React.JSX.Element {
         )}
       </select>
       {spacesError && <p className="mt-1.5 text-[11px] leading-relaxed text-red-400">{spacesError}</p>}
+
+      <div className="mb-1.5 mt-2 flex items-center justify-between">
+        <span className="text-[11px] text-zinc-500">Post caption</span>
+        <button
+          onClick={() => void generateCaption()}
+          disabled={captionBusy || posting}
+          className="flex items-center gap-1 rounded-md border border-surface-600 px-2 py-1 text-[11px] font-medium text-zinc-300 transition hover:bg-surface-800 disabled:opacity-60"
+        >
+          {captionBusy ? <Loader2 size={11} className="animate-spin" /> : <Sparkles size={11} />}
+          {captionBusy ? 'Writing…' : clip.workvivoCaption ? 'Regenerate' : 'Generate'}
+        </button>
+      </div>
+      <textarea
+        value={clip.workvivoCaption ?? ''}
+        onChange={(e) => updateClipLocal({ ...clip, workvivoCaption: e.target.value })}
+        onBlur={() => void updateClip(clip)}
+        disabled={posting}
+        placeholder="Write a caption for your colleagues, or generate one in your brand voice."
+        rows={3}
+        className="w-full resize-none rounded-lg border border-surface-600 bg-surface-850 px-3 py-2 text-xs leading-relaxed text-zinc-200 placeholder:text-zinc-600 focus:border-white/25 focus:outline-none disabled:opacity-60"
+      />
+      {captionError && (
+        <p className="mt-1.5 text-[11px] leading-relaxed text-red-400">{captionError}</p>
+      )}
 
       {posting ? (
         <div className="mt-2 rounded-lg border border-surface-600 px-3 py-2.5">
@@ -701,7 +743,8 @@ function WorkvivoPostBlock({ clip }: { clip: Clip }): React.JSX.Element {
         </div>
       )}
       <p className="mt-2 text-[11px] leading-relaxed text-zinc-500">
-        Renders the clip and uploads it with the caption above as the post text.
+        Renders the clip and posts it to the selected space with the caption above. Large clips are
+        compressed automatically to fit WorkVivo&apos;s upload limit.
       </p>
     </div>
   )

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -16,12 +16,15 @@ import {
   Languages,
   Loader2,
   Send,
-  Palette
+  Palette,
+  MessageSquareQuote,
+  Search
 } from 'lucide-react'
 import { useStore } from '../store'
 import { DEFAULT_BRAND_COLORS, resolveCaptionStyle } from '@shared/captionStyles'
 import type {
   BrandColors,
+  BrandVoiceSettings,
   EncoderPreference,
   ImportProgress,
   QualityPreference,
@@ -69,6 +72,18 @@ const WATERMARK_POSITIONS: Array<{ value: WatermarkPosition; label: string }> = 
   { value: 'bottom-right', label: 'Bottom right' }
 ]
 
+type SectionId = 'general' | 'export' | 'branding' | 'voice' | 'workvivo' | 'fonts' | 'updates'
+
+const SECTIONS: Array<{ id: SectionId; label: string; icon: typeof KeyRound }> = [
+  { id: 'general', label: 'API & models', icon: KeyRound },
+  { id: 'export', label: 'Export', icon: MonitorPlay },
+  { id: 'branding', label: 'Branding', icon: Stamp },
+  { id: 'voice', label: 'Brand voice', icon: MessageSquareQuote },
+  { id: 'workvivo', label: 'WorkVivo', icon: Send },
+  { id: 'fonts', label: 'Fonts', icon: Type },
+  { id: 'updates', label: 'Updates', icon: RefreshCw }
+]
+
 export default function SettingsModal(): React.JSX.Element {
   const settings = useStore((s) => s.settings)
   const setSettingsOpen = useStore((s) => s.setSettingsOpen)
@@ -80,6 +95,7 @@ export default function SettingsModal(): React.JSX.Element {
   const [saving, setSaving] = useState(false)
   const [gpuProgress, setGpuProgress] = useState<ImportProgress | null>(null)
   const [gpuError, setGpuError] = useState<string | null>(null)
+  const [section, setSection] = useState<SectionId>('general')
 
   useEffect(() => window.clipforge.onGpuProgress(setGpuProgress), [])
 
@@ -113,28 +129,48 @@ export default function SettingsModal(): React.JSX.Element {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
       onClick={() => setSettingsOpen(false)}
     >
       <div
-        className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-2xl border border-white/10 bg-surface-900/85 p-6 shadow-2xl shadow-black/60 backdrop-blur-2xl"
+        className="flex h-[85vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-surface-900/90 shadow-2xl shadow-black/60 backdrop-blur-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Settings</h2>
+        <aside className="flex w-56 shrink-0 flex-col border-r border-surface-700 bg-surface-900/50 p-3">
+          <h2 className="px-2 py-2 text-lg font-semibold">Settings</h2>
+          <nav className="mt-1 flex flex-col gap-0.5">
+            {SECTIONS.map(({ id, label, icon: Icon }) => (
+              <button
+                key={id}
+                onClick={() => setSection(id)}
+                className={`flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium transition ${
+                  section === id
+                    ? 'bg-white/[0.08] text-zinc-100'
+                    : 'text-zinc-400 hover:bg-surface-800 hover:text-zinc-200'
+                }`}
+              >
+                <Icon size={15} className={section === id ? 'text-accent-400' : ''} />
+                {label}
+              </button>
+            ))}
+          </nav>
+        </aside>
+
+        <div className="relative flex-1 overflow-y-auto p-6">
           <button
             onClick={() => setSettingsOpen(false)}
-            className="rounded-lg p-1.5 text-zinc-500 transition hover:bg-surface-800 hover:text-zinc-200"
+            className="absolute right-4 top-4 z-10 rounded-lg p-1.5 text-zinc-500 transition hover:bg-surface-800 hover:text-zinc-200"
           >
             <X size={18} />
           </button>
-        </div>
 
-        <div className="mt-5">
-          <label className="flex items-center gap-2 text-sm font-medium">
-            <KeyRound size={15} className="text-accent-400" />
-            OpenAI API key
-          </label>
+          {section === 'general' && (
+            <div className="max-w-xl">
+              <div>
+                <label className="flex items-center gap-2 text-sm font-medium">
+                  <KeyRound size={15} className="text-accent-400" />
+                  OpenAI API key
+                </label>
           <p className="mt-1 text-xs leading-relaxed text-zinc-500">
             Used for Whisper transcription and clip analysis. Stored encrypted on this machine
             and never sent anywhere except the OpenAI API.
@@ -208,9 +244,22 @@ export default function SettingsModal(): React.JSX.Element {
               </option>
             ))}
           </select>
-        </div>
+              </div>
 
-        <div className="mt-5 border-t border-surface-700 pt-5">
+              <button
+                onClick={() => void save()}
+                disabled={saving}
+                className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-zinc-100 px-4 py-2.5 text-sm font-semibold text-zinc-900 transition hover:bg-white disabled:opacity-60"
+              >
+                {saved ? <Check size={16} /> : null}
+                {saved ? 'Saved' : saving ? 'Saving…' : 'Save settings'}
+              </button>
+            </div>
+          )}
+
+          {section === 'export' && (
+            <div className="max-w-xl">
+              <div>
           <label className="flex items-center gap-2 text-sm font-medium">
             <MonitorPlay size={15} className="text-accent-400" />
             Export encoder
@@ -290,20 +339,15 @@ export default function SettingsModal(): React.JSX.Element {
             ))}
           </div>
         </div>
+            </div>
+          )}
 
-        <BrandingSection />
-        <WorkvivoSection />
-        <FontsSection />
-        <UpdatesSection />
-
-        <button
-          onClick={() => void save()}
-          disabled={saving}
-          className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-zinc-100 px-4 py-2.5 text-sm font-semibold text-zinc-900 transition hover:bg-white disabled:opacity-60"
-        >
-          {saved ? <Check size={16} /> : null}
-          {saved ? 'Saved' : saving ? 'Saving…' : 'Save settings'}
-        </button>
+          {section === 'branding' && <BrandingSection />}
+          {section === 'voice' && <BrandVoiceSection />}
+          {section === 'workvivo' && <WorkvivoSection />}
+          {section === 'fonts' && <FontsSection />}
+          {section === 'updates' && <UpdatesSection />}
+        </div>
       </div>
     </div>
   )
@@ -321,7 +365,7 @@ function BrandingSection(): React.JSX.Element {
   }
 
   return (
-    <div className="mt-5 border-t border-surface-700 pt-5">
+    <div className="max-w-xl">
       <label className="flex items-center gap-2 text-sm font-medium">
         <Stamp size={15} className="text-accent-400" />
         Branding
@@ -588,6 +632,78 @@ function ColorField({
 }
 
 /**
+ * Brand tone-of-voice and style guidance. Free-text fields that steer AI
+ * caption generation (WorkVivo posts today). Persisted on blur so typing does
+ * not fire a save per keystroke.
+ */
+function BrandVoiceSection(): React.JSX.Element {
+  const settings = useStore((s) => s.settings)
+  const saveSettings = useStore((s) => s.saveSettings)
+  const voice: BrandVoiceSettings = settings?.brandVoice ?? {
+    brandName: '',
+    tone: '',
+    style: '',
+    avoid: ''
+  }
+
+  const inputClass =
+    'mt-2 w-full rounded-xl border border-surface-600 bg-surface-850 px-3.5 py-2.5 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-white/25 focus:outline-none'
+
+  // Uncontrolled inputs (defaultValue + save on blur) so typing does not fire a
+  // save per keystroke; keyed on the stored value so they re-seed once settings
+  // load. Only persist when the value actually changed.
+  const commit = (key: keyof BrandVoiceSettings, value: string): void => {
+    if (value !== voice[key]) void saveSettings({ brandVoice: { [key]: value } })
+  }
+
+  const field = (
+    key: keyof BrandVoiceSettings,
+    label: string,
+    placeholder: string,
+    rows: number
+  ): React.JSX.Element => (
+    <div className="mt-4">
+      <span className="text-[11px] font-medium text-zinc-400">{label}</span>
+      {rows > 1 ? (
+        <textarea
+          key={voice[key]}
+          defaultValue={voice[key]}
+          rows={rows}
+          onBlur={(e) => commit(key, e.target.value)}
+          placeholder={placeholder}
+          className={`${inputClass} resize-none leading-relaxed`}
+        />
+      ) : (
+        <input
+          key={voice[key]}
+          defaultValue={voice[key]}
+          onBlur={(e) => commit(key, e.target.value)}
+          placeholder={placeholder}
+          className={inputClass}
+        />
+      )}
+    </div>
+  )
+
+  return (
+    <div className="max-w-xl">
+      <label className="flex items-center gap-2 text-sm font-medium">
+        <MessageSquareQuote size={15} className="text-accent-400" />
+        Brand voice
+      </label>
+      <p className="mt-1 text-xs leading-relaxed text-zinc-500">
+        Steers AI-generated captions (like WorkVivo posts) so they sound like your organisation.
+        Leave blank for a neutral, friendly default.
+      </p>
+      {field('brandName', 'Brand / organisation name', 'e.g. your company name', 1)}
+      {field('tone', 'Tone of voice', 'e.g. warm, upbeat and human; confident but never salesy', 2)}
+      {field('style', 'Writing style', 'e.g. British English, short sentences, no emojis', 2)}
+      {field('avoid', 'Things to avoid', 'e.g. no hashtags, no hype, no corporate jargon', 2)}
+    </div>
+  )
+}
+
+/**
  * WorkVivo connector: posts clips straight to a chosen WorkVivo space. Auth is
  * an org-level app token (Bearer) plus the Organisation ID header — not the
  * user's SSO login — so posts appear as the configured identity.
@@ -605,6 +721,9 @@ function WorkvivoSection(): React.JSX.Element {
   const [postAsUserId, setPostAsUserId] = useState(wv?.postAsUserId ?? '')
   const [busy, setBusy] = useState(false)
   const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
+  const [lookupEmail, setLookupEmail] = useState('')
+  const [lookupBusy, setLookupBusy] = useState(false)
+  const [lookupMsg, setLookupMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
   useEffect(() => {
     if (wv?.configured) void loadSpaces()
@@ -633,11 +752,32 @@ function WorkvivoSection(): React.JSX.Element {
     }
   }
 
+  const lookUp = async (): Promise<void> => {
+    setLookupBusy(true)
+    setLookupMsg(null)
+    try {
+      const user = await window.clipforge.findWorkvivoUser(lookupEmail.trim())
+      setPostAsUserId(user.id)
+      await saveSettings({ workvivo: { postAsUserId: user.id } })
+      setLookupMsg({ ok: true, text: `Found ${user.name} (id ${user.id}) and saved.` })
+    } catch (err) {
+      setLookupMsg({
+        ok: false,
+        text:
+          err instanceof Error
+            ? err.message.replace(/^Error invoking remote method '[^']+':\s*(Error:\s*)?/, '')
+            : String(err)
+      })
+    } finally {
+      setLookupBusy(false)
+    }
+  }
+
   const inputClass =
     'mt-1.5 w-full rounded-xl border border-surface-600 bg-surface-850 px-3.5 py-2.5 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-white/25 focus:outline-none'
 
   return (
-    <div className="mt-5 border-t border-surface-700 pt-5">
+    <div className="max-w-xl">
       <label className="flex items-center gap-2 text-sm font-medium">
         <Send size={15} className="text-accent-400" />
         WorkVivo
@@ -677,13 +817,43 @@ function WorkvivoSection(): React.JSX.Element {
         />
       </div>
       <div className="mt-3">
-        <span className="text-[11px] text-zinc-500">Post as — WorkVivo user ID (optional)</span>
+        <span className="text-[11px] text-zinc-500">Post as — WorkVivo user ID (required)</span>
         <input
           value={postAsUserId}
           onChange={(e) => setPostAsUserId(e.target.value)}
-          placeholder="Shared Comms account user id"
+          placeholder="e.g. 4821 (a shared Comms account)"
           className={inputClass}
         />
+        <p className="mt-1 text-[11px] leading-relaxed text-zinc-500">
+          WorkVivo attributes every post to a user, so this is required to post. Don&apos;t know the
+          id? Look it up by email below (needs the connection saved first).
+        </p>
+        <div className="mt-2 flex gap-2">
+          <input
+            type="email"
+            value={lookupEmail}
+            onChange={(e) => setLookupEmail(e.target.value)}
+            placeholder="you@company.com"
+            className="min-w-0 flex-1 rounded-xl border border-surface-600 bg-surface-850 px-3.5 py-2 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-white/25 focus:outline-none"
+          />
+          <button
+            onClick={() => void lookUp()}
+            disabled={lookupBusy || !lookupEmail.trim()}
+            className="flex shrink-0 items-center gap-1.5 rounded-xl border border-surface-600 px-3 py-2 text-xs font-medium text-zinc-300 transition hover:bg-surface-800 disabled:opacity-60"
+          >
+            {lookupBusy ? <Loader2 size={13} className="animate-spin" /> : <Search size={13} />}
+            Look up
+          </button>
+        </div>
+        {lookupMsg && (
+          <p
+            className={`mt-1.5 text-[11px] leading-relaxed ${
+              lookupMsg.ok ? 'text-emerald-400' : 'text-red-400'
+            }`}
+          >
+            {lookupMsg.text}
+          </p>
+        )}
       </div>
 
       {wv?.configured && spaces.length > 0 && (
@@ -733,7 +903,7 @@ function FontsSection(): React.JSX.Element {
   const [adding, setAdding] = useState(false)
 
   return (
-    <div className="mt-5 border-t border-surface-700 pt-5">
+    <div className="max-w-xl">
       <label className="flex items-center gap-2 text-sm font-medium">
         <Type size={15} className="text-accent-400" />
         Custom fonts
@@ -797,7 +967,7 @@ function UpdatesSection(): React.JSX.Element {
   const installUpdate = useStore((s) => s.installUpdate)
 
   return (
-    <div className="mt-5 border-t border-surface-700 pt-5">
+    <div className="max-w-xl">
       <label className="flex items-center gap-2 text-sm font-medium">
         <RefreshCw size={15} className="text-accent-400" />
         App updates

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -450,6 +450,7 @@ export const useStore = create<AppState>((set, get) => ({
   postClipToWorkvivo: async (clipId, spaceId) => {
     const project = get().project
     if (!project) return
+    const clip = project.clips.find((c) => c.id === clipId)
     set({
       workvivoPosts: {
         ...get().workvivoPosts,
@@ -457,7 +458,12 @@ export const useStore = create<AppState>((set, get) => ({
       }
     })
     try {
-      const result = await window.clipforge.postClipToWorkvivo(project.id, clipId, spaceId)
+      const result = await window.clipforge.postClipToWorkvivo(
+        project.id,
+        clipId,
+        spaceId,
+        clip?.workvivoCaption ?? null
+      )
       set({
         workvivoPosts: {
           ...get().workvivoPosts,

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -101,6 +101,8 @@ interface AppState {
   updateClipLocal: (clip: Clip) => void
   generateCaption: (clipId: string) => Promise<void>
   captionBusy: Record<string, boolean>
+  generateWorkvivoCaption: (clipId: string) => Promise<void>
+  workvivoCaptionBusy: Record<string, boolean>
   updateTranscriptWord: (segmentId: number, wordIndex: number, text: string) => Promise<void>
   exportClip: (clipId: string) => Promise<void>
   cancelExport: (clipId: string) => Promise<void>
@@ -143,6 +145,7 @@ export const useStore = create<AppState>((set, get) => ({
   updateDownload: { status: 'idle', progress: 0 },
   sourceUpdate: { status: 'idle', message: '' },
   captionBusy: {},
+  workvivoCaptionBusy: {},
 
   init: async () => {
     const [settings, projects, customFonts] = await Promise.all([
@@ -329,6 +332,32 @@ export const useStore = create<AppState>((set, get) => ({
       const busy = { ...get().captionBusy }
       delete busy[clipId]
       set({ captionBusy: busy })
+    }
+  },
+
+  generateWorkvivoCaption: async (clipId) => {
+    const project = get().project
+    if (!project || get().workvivoCaptionBusy[clipId]) return
+    set({ workvivoCaptionBusy: { ...get().workvivoCaptionBusy, [clipId]: true } })
+    try {
+      const updated = await window.clipforge.generateWorkvivoCaption(project.id, clipId)
+      const fresh = updated.clips.find((c) => c.id === clipId)
+      const current = get().project
+      // Only graft the caption on: other clip edits may be in flight.
+      if (fresh && current?.id === updated.id) {
+        set({
+          project: {
+            ...current,
+            clips: current.clips.map((c) =>
+              c.id === clipId ? { ...c, workvivoCaption: fresh.workvivoCaption } : c
+            )
+          }
+        })
+      }
+    } finally {
+      const busy = { ...get().workvivoCaptionBusy }
+      delete busy[clipId]
+      set({ workvivoCaptionBusy: busy })
     }
   },
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -110,6 +110,12 @@ export interface Clip {
   summary: string
   /** AI-generated social post caption (TikTok-style); null until generated. */
   caption?: string | null
+  /**
+   * AI-generated caption for internal WorkVivo posts (brand-voiced, not
+   * hashtag-led); null until generated. Kept separate from `caption` because
+   * the two registers differ. Falls back to `caption`/`title` when unset.
+   */
+  workvivoCaption?: string | null
   viralityScore: number
   viralityReason: string
   /** One-line LLM assessment of what the visuals add/cost; null until scored. */
@@ -217,6 +223,23 @@ export interface BrandColors {
   outlineColor: string | null
   hookTextColor: string
   hookBackgroundColor: string
+}
+
+/**
+ * Editable brand tone-of-voice and style guidance that steers AI caption
+ * generation (used for WorkVivo captions today, and available to any future
+ * generated copy). All fields are free text; an empty string means "no
+ * preference" and the generator falls back to sensible defaults.
+ */
+export interface BrandVoiceSettings {
+  /** Organisation/brand name, woven into captions where it reads naturally. */
+  brandName: string
+  /** How the brand should sound, e.g. "warm, upbeat, human, never salesy". */
+  tone: string
+  /** Writing style/format rules, e.g. "British English, short sentences, no emojis". */
+  style: string
+  /** Things to avoid, e.g. "no hashtags, no hype, no corporate jargon". */
+  avoid: string
 }
 
 /** App-wide branding applied to the preview and burned into exports. */
@@ -374,6 +397,7 @@ export interface AppSettings {
   quality: QualityPreference
   gpu: GpuEncoderStatus
   branding: BrandingSettings
+  brandVoice: BrandVoiceSettings
   appVersion: string
   /** Browser to borrow login cookies from for URL imports ('' = none). */
   importCookiesBrowser: BrowserCookieSource
@@ -391,6 +415,7 @@ export interface SettingsUpdate {
   encoder?: EncoderPreference
   quality?: QualityPreference
   branding?: Partial<BrandingSettings>
+  brandVoice?: Partial<BrandVoiceSettings>
   importCookiesBrowser?: BrowserCookieSource
   clearImportCookiesFile?: boolean
   workvivo?: WorkvivoSettingsUpdate

--- a/tests/workvivo.test.ts
+++ b/tests/workvivo.test.ts
@@ -2,25 +2,33 @@ import { describe, expect, it } from 'vitest'
 import { deriveWorkvivoApiBase, extractPermalink } from '../src/main/pipeline/workvivo'
 
 describe('deriveWorkvivoApiBase', () => {
-  it('appends /api/v1 to a full org URL', () => {
-    expect(deriveWorkvivoApiBase('https://acme.workvivo.com')).toBe('https://acme.workvivo.com/api/v1')
+  it('maps a .com tenant to the central api.workvivo.com host', () => {
+    expect(deriveWorkvivoApiBase('https://acme.workvivo.com')).toBe('https://api.workvivo.com/v1')
   })
 
-  it('handles the .us region', () => {
-    expect(deriveWorkvivoApiBase('https://acme.workvivo.us')).toBe('https://acme.workvivo.us/api/v1')
+  it('maps a .us tenant to the api.workvivo.us region host', () => {
+    expect(deriveWorkvivoApiBase('https://acme.workvivo.us')).toBe('https://api.workvivo.us/v1')
   })
 
   it('adds a scheme to a bare host', () => {
-    expect(deriveWorkvivoApiBase('acme.workvivo.com')).toBe('https://acme.workvivo.com/api/v1')
+    expect(deriveWorkvivoApiBase('acme.workvivo.com')).toBe('https://api.workvivo.com/v1')
   })
 
-  it('ignores any path already on the URL and uses the origin', () => {
+  it('ignores any path on the URL and keys off the tenant TLD only', () => {
+    expect(deriveWorkvivoApiBase('https://acme.workvivo.us/dashboard')).toBe(
+      'https://api.workvivo.us/v1'
+    )
     expect(deriveWorkvivoApiBase('https://acme.workvivo.com/api/v1/')).toBe(
-      'https://acme.workvivo.com/api/v1'
+      'https://api.workvivo.com/v1'
     )
-    expect(deriveWorkvivoApiBase('https://acme.workvivo.com/dashboard')).toBe(
-      'https://acme.workvivo.com/api/v1'
-    )
+  })
+
+  it('is idempotent when given the API host itself', () => {
+    expect(deriveWorkvivoApiBase('https://api.workvivo.com/v1')).toBe('https://api.workvivo.com/v1')
+  })
+
+  it('defaults a non-WorkVivo host to the .com region', () => {
+    expect(deriveWorkvivoApiBase('https://intranet.acme.co.uk')).toBe('https://api.workvivo.com/v1')
   })
 
   it('returns null for empty or unusable values', () => {


### PR DESCRIPTION
## Summary

Gets WorkVivo clip posting working end to end, adds a brand-voiced WorkVivo caption, and reorganises settings into a sectioned page.

### WorkVivo posting
- **Correct API host/region.** The Customer API lives on the central regional host `https://api.workvivo.<region>/v1` (region from the tenant TLD), not the tenant web subdomain. Fixes the earlier 404s.
- **Correct create-post contract.** Posts via `POST /v1/updates` ("Create an update") with `text`, `created_at`, `user_id`, and space targeting through `audience[type]=spaces` + `audience[spaces][0]`.
- **413 handling.** The API caps inline upload well below its web uploader and offers no chunked upload, so oversized clips are auto-compressed to a target size and retried at progressively smaller targets on a 413.
- **Clearer failures.** Fail fast when the "Post as" user id is unset; surface WorkVivo's actual message on 403/404 rather than guessed wording. Spaces pagination uses `skip`/`take`.
- **User-id lookup.** Resolve the "Post as" WorkVivo user id by email from Settings.

### Captions
- A separate, brand-voiced WorkVivo caption (internal-comms register) generated and editable directly in the post block, kept distinct from the TikTok-style social caption.

### Settings
- Editable **brand voice** settings (name / tone / style / avoid) that steer caption generation.
- Settings modal reworked into a **full-screen page with a section sidebar** (API & models, Export, Branding, Brand voice, WorkVivo, Fonts, Updates).

## Testing
- `npm run typecheck`, `npm run build`, and `npm run test` (169 tests) all pass.
- Verified live end to end against a real tenant: auth, space listing, user attribution, 413 auto-compression, and a successful post to a space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches external WorkVivo integration, multipart uploads, and ffmpeg re-encoding on the post path; misconfiguration or compression edge cases could still fail posts, but behavior is more aligned with the documented API.
> 
> **Overview**
> Fixes **WorkVivo clip posting** against the real Customer API: derives the central regional base (`api.workvivo.<region>/v1`), paginates spaces with `skip`/`take`, creates updates with `created_at`, required `user_id`, and space audience fields, and adds **email lookup** for the “Post as” user. Posting now **requires** that user id and surfaces clearer 403/404/413 errors.
> 
> Large uploads are handled by **`compressToTargetSize`** (H.264 re-encode under a byte budget, optional downscale) with pre-shrink above 64 MB and **413 retries** at smaller targets, always recompressing from the original render.
> 
> Adds a separate **`workvivoCaption`** (AI internal-comms tone via new `generateWorkvivoCaption` + persisted **brand voice** settings), editable in the editor post block, and passes it through IPC when posting. The **settings UI** becomes a wide modal with a section sidebar (including Brand voice and expanded WorkVivo setup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5f14bb790e6d3f278d7591841a0b9a0304d71c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->