### PR TITLE
Fix face tracking hang on screen recordings with no faces

### DIFF
--- a/scripts/test-youtube.ts
+++ b/scripts/test-youtube.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path'
 import assert from 'node:assert/strict'
 import { ensureYtDlp, fetchUrlMeta, downloadUrlVideo } from '../src/main/pipeline/ytdlp'
 import { probeVideo, extractAudioChunks } from '../src/main/pipeline/ffmpeg'
-import { analyzeClipFocus } from '../src/main/pipeline/faces'
+import { analyzeClipFocus, applyFocusAnalysis } from '../src/main/pipeline/faces'
 import { focusAt } from '../src/shared/focusTrack'
 import { transcribeChunks } from '../src/main/pipeline/transcribe'
 import { detectHighlights } from '../src/main/pipeline/highlights'
@@ -88,8 +88,10 @@ async function main(): Promise<void> {
   console.log('4. Face detection / auto-reframe track…')
   // Sample a window starting 25% in: long shows often open with title cards.
   const fwStart = info.durationSec * 0.25
-  const track = await analyzeClipFocus(videoPath, fwStart, Math.min(fwStart + 30, info.durationSec))
+  const analysis = await analyzeClipFocus(videoPath, fwStart, Math.min(fwStart + 30, info.durationSec))
+  const track = analysis.focusTrack
   assert.ok(track && track.length >= 1, 'expected a focus track on footage with a face')
+  assert.equal(analysis.contentType, 'speaker')
   console.log(`   ${track.length} segment(s):`, track.map((k) => `t=${k.t.toFixed(1)} x=${k.x.toFixed(2)}`).join(', '))
   const sampled = focusAt(track, 2)
   assert.ok(sampled >= 0 && sampled <= 1)
@@ -137,8 +139,7 @@ async function main(): Promise<void> {
   top.visualSummary = visual.visualSummary
 
   console.log('8. Rendering top clip with auto framing + captions…')
-  top.focusTrack = await analyzeClipFocus(videoPath, top.edit.start, top.edit.end)
-  if (top.focusTrack) top.edit.framing = 'auto'
+  applyFocusAnalysis(top, await analyzeClipFocus(videoPath, top.edit.start, top.edit.end))
   top.edit.showTitle = true
   const out = join(WORK, 'top-clip.mp4')
   await renderClip({ clip: top, source: info, transcript, outputPath: out })

--- a/src/main/pipeline/asd.ts
+++ b/src/main/pipeline/asd.ts
@@ -116,12 +116,15 @@ export interface AsdAnalysis {
   frameCount: number
   sceneCuts: number[]
   fps: number
+  /** Share of strided detection frames that contained at least one face. */
+  faceFrameRatio: number
 }
 
 interface DetectionPass {
   facesPerFrame: Array<FaceBox[] | null>
   sceneCuts: number[]
   frameCount: number
+  faceFrameRatio: number
 }
 
 /** Whether face detection should stop early on sparse / absent faces (unit-tested). */
@@ -212,11 +215,12 @@ async function runDetectionPass(
   const frameCount = abortedEarly
     ? Math.max(facesPerFrame.length, Math.round(duration * ASD_FPS))
     : facesPerFrame.length
+  const faceFrameRatio = detectionFrames > 0 ? framesWithFaces / detectionFrames : 0
   // A dissolve registers on several neighbouring frames; keep only the last
   // of each cluster (when the new shot has settled).
   const mergeWindow = Math.max(1, Math.round(CUT_MERGE_SEC * ASD_FPS))
   const sceneCuts = rawCuts.filter((cut, i) => i === rawCuts.length - 1 || rawCuts[i + 1] - cut > mergeWindow)
-  return { facesPerFrame, sceneCuts, frameCount }
+  return { facesPerFrame, sceneCuts, frameCount, faceFrameRatio }
 }
 
 /** Bilinear sample of a square region into a CROP_SIZE² grayscale patch. */
@@ -447,7 +451,13 @@ export async function analyzeClipASD(
     tracks.length === 0 ||
     trackCoverageRatio(tracks, detection.frameCount) < MIN_TRACK_COVERAGE
   ) {
-    return { tracks: [], frameCount: detection.frameCount, sceneCuts: detection.sceneCuts, fps: ASD_FPS }
+    return {
+      tracks: [],
+      frameCount: detection.frameCount,
+      sceneCuts: detection.sceneCuts,
+      fps: ASD_FPS,
+      faceFrameRatio: detection.faceFrameRatio
+    }
   }
 
   const cropW = Math.min(CROP_PASS_WIDTH, info.width || CROP_PASS_WIDTH)
@@ -484,6 +494,7 @@ export async function analyzeClipASD(
     tracks: scored,
     frameCount: detection.frameCount,
     sceneCuts: detection.sceneCuts,
-    fps: ASD_FPS
+    fps: ASD_FPS,
+    faceFrameRatio: detection.faceFrameRatio
   }
 }

--- a/src/main/pipeline/asd.ts
+++ b/src/main/pipeline/asd.ts
@@ -57,6 +57,21 @@ const CROP_PASS_WIDTH = 640
 const ASD_SCENE_CUT_THRESHOLD = 24
 /** Cuts closer together than this are one transition (dissolves span frames). */
 const CUT_MERGE_SEC = 0.3
+/**
+ * Screencasts and slide decks rarely have faces; scanning the whole clip at
+ * 25 fps is slow and looks like a hang. After this many seconds, bail out
+ * when detections are too sparse to ever produce a focus track.
+ */
+const FACE_PROBE_SEC = 8
+/** Stop scanning once no face has been seen for this long (e.g. Zoom → screen share). */
+const FACE_ABSENT_ABORT_SEC = 3
+/** Minimum strided detection frames that must contain a face to keep scanning. */
+const MIN_FACE_DETECTIONS = 3
+/**
+ * Tracks must cover at least this fraction of analysis frames before we run
+ * the heavy crop + LR-ASD passes (buildFocusTrack needs ~30%).
+ */
+const MIN_TRACK_COVERAGE = 0.25
 
 let sessionsPromise: Promise<{
   frontend: ort.InferenceSession
@@ -109,6 +124,31 @@ interface DetectionPass {
   frameCount: number
 }
 
+/** Whether face detection should stop early on sparse / absent faces (unit-tested). */
+export function shouldAbortFaceDetection(
+  frameIndex: number,
+  detectionFrames: number,
+  framesWithFaces: number,
+  lastFaceFrame: number,
+  fps: number = ASD_FPS
+): boolean {
+  const probeEnd = Math.round(FACE_PROBE_SEC * fps)
+  const absentLimit = Math.round(FACE_ABSENT_ABORT_SEC * fps)
+  const probeDetections = Math.ceil(probeEnd / DETECT_STRIDE)
+  if (frameIndex >= probeEnd && detectionFrames >= probeDetections && framesWithFaces < MIN_FACE_DETECTIONS) {
+    return true
+  }
+  if (lastFaceFrame >= 0 && frameIndex - lastFaceFrame >= absentLimit) return true
+  return false
+}
+
+/** Fraction of analysis frames covered by face tracks (unit-tested). */
+export function trackCoverageRatio(tracks: FaceTrack[], frameCount: number): number {
+  let covered = 0
+  for (const t of tracks) covered += t.boxes.length
+  return covered / Math.max(1, frameCount)
+}
+
 /** Pass 1: stream small RGB frames; detect scene cuts and faces (strided). */
 async function runDetectionPass(
   videoPath: string,
@@ -119,24 +159,55 @@ async function runDetectionPass(
   const facesPerFrame: Array<FaceBox[] | null> = []
   const rawCuts: number[] = []
   let prev: Buffer | null = null
-  const frameCount = await streamRawFrames(
-    [
-      '-ss', startSec.toFixed(3),
-      '-t', duration.toFixed(3),
-      '-i', videoPath,
-      '-vf', `fps=${ASD_FPS},scale=${MODEL_W}:${MODEL_H}`,
-      '-f', 'rawvideo',
-      '-pix_fmt', 'rgb24'
-    ],
-    MODEL_W * MODEL_H * 3,
-    async (frame, f) => {
-      signal?.throwIfAborted()
-      if (prev && frameDifference(prev, frame) > ASD_SCENE_CUT_THRESHOLD) rawCuts.push(f)
-      facesPerFrame.push(f % DETECT_STRIDE === 0 ? await detectFaces(frame) : null)
-      prev = Buffer.from(frame)
-    },
-    signal
-  )
+  let detectionFrames = 0
+  let framesWithFaces = 0
+  let lastFaceFrame = -1
+  let abortedEarly = false
+  const passAbort = new AbortController()
+  const onParentAbort = (): void => passAbort.abort()
+  signal?.addEventListener('abort', onParentAbort, { once: true })
+
+  try {
+    await streamRawFrames(
+      [
+        '-ss', startSec.toFixed(3),
+        '-t', duration.toFixed(3),
+        '-i', videoPath,
+        '-vf', `fps=${ASD_FPS},scale=${MODEL_W}:${MODEL_H}`,
+        '-f', 'rawvideo',
+        '-pix_fmt', 'rgb24'
+      ],
+      MODEL_W * MODEL_H * 3,
+      async (frame, f) => {
+        signal?.throwIfAborted()
+        if (prev && frameDifference(prev, frame) > ASD_SCENE_CUT_THRESHOLD) rawCuts.push(f)
+        if (f % DETECT_STRIDE === 0) {
+          const faces = await detectFaces(frame)
+          facesPerFrame.push(faces)
+          detectionFrames++
+          if (faces.length > 0) {
+            framesWithFaces++
+            lastFaceFrame = f
+          }
+        } else {
+          facesPerFrame.push(null)
+        }
+        prev = Buffer.from(frame)
+        if (shouldAbortFaceDetection(f, detectionFrames, framesWithFaces, lastFaceFrame)) {
+          abortedEarly = true
+          passAbort.abort()
+        }
+      },
+      passAbort.signal
+    )
+  } catch (err) {
+    if (!abortedEarly && !signal?.aborted) throw err
+    signal?.throwIfAborted()
+  } finally {
+    signal?.removeEventListener('abort', onParentAbort)
+  }
+
+  const frameCount = facesPerFrame.length
   // A dissolve registers on several neighbouring frames; keep only the last
   // of each cluster (when the new shot has settled).
   const mergeWindow = Math.max(1, Math.round(CUT_MERGE_SEC * ASD_FPS))
@@ -368,7 +439,10 @@ export async function analyzeClipASD(
   if (detection.frameCount === 0) return null
 
   const tracks = buildFaceTracks(detection.facesPerFrame, detection.sceneCuts, ASD_FPS)
-  if (tracks.length === 0) {
+  if (
+    tracks.length === 0 ||
+    trackCoverageRatio(tracks, detection.frameCount) < MIN_TRACK_COVERAGE
+  ) {
     return { tracks: [], frameCount: detection.frameCount, sceneCuts: detection.sceneCuts, fps: ASD_FPS }
   }
 

--- a/src/main/pipeline/asd.ts
+++ b/src/main/pipeline/asd.ts
@@ -207,7 +207,11 @@ async function runDetectionPass(
     signal?.removeEventListener('abort', onParentAbort)
   }
 
-  const frameCount = facesPerFrame.length
+  // Keep the full clip length as the denominator after bailout; the skipped
+  // suffix is effectively "no face", not "not part of the clip".
+  const frameCount = abortedEarly
+    ? Math.max(facesPerFrame.length, Math.round(duration * ASD_FPS))
+    : facesPerFrame.length
   // A dissolve registers on several neighbouring frames; keep only the last
   // of each cluster (when the new shot has settled).
   const mergeWindow = Math.max(1, Math.round(CUT_MERGE_SEC * ASD_FPS))

--- a/src/main/pipeline/faces.ts
+++ b/src/main/pipeline/faces.ts
@@ -85,31 +85,42 @@ async function sampleFaceCentres(
     // Face detection per frame is independent — run inferences concurrently
     // (ONNX Runtime queues session.run calls safely across its thread pool).
     const facesPerFrame: FaceBox[][] = new Array(frameCount).fill(null).map(() => [])
+    const completedFrames = new Array<boolean>(frameCount).fill(false)
     let detectionFrames = 0
     let framesWithFaces = 0
     let lastFaceFrame = -1
+    let processedThrough = -1
     let abortedEarly = false
+    let effectiveCount = frameCount
     const probeEnd = Math.round(8 * SAMPLE_FPS)
     const absentLimit = Math.round(3 * SAMPLE_FPS)
     await mapLimit(frames, FACE_INFERENCE_CONCURRENCY, async (frame, f) => {
-      if (abortedEarly) return
+      if (abortedEarly && f >= effectiveCount) return
       signal?.throwIfAborted()
       const faces = await detectFaces(frame)
       facesPerFrame[f] = faces
-      detectionFrames++
-      if (faces.length > 0) {
-        framesWithFaces++
-        lastFaceFrame = f
+      completedFrames[f] = true
+      if (abortedEarly) return
+
+      // Concurrent inferences finish out of order; only make bailout decisions
+      // from a contiguous analysed prefix so no frame inside it is skipped.
+      while (processedThrough + 1 < frameCount && completedFrames[processedThrough + 1]) {
+        processedThrough++
+        detectionFrames++
+        if (facesPerFrame[processedThrough].length > 0) {
+          framesWithFaces++
+          lastFaceFrame = processedThrough
+        }
       }
       if (
-        (f >= probeEnd && detectionFrames >= probeEnd && framesWithFaces < 3) ||
-        (lastFaceFrame >= 0 && f - lastFaceFrame >= absentLimit)
+        (processedThrough >= probeEnd && detectionFrames >= probeEnd && framesWithFaces < 3) ||
+        (lastFaceFrame >= 0 && processedThrough - lastFaceFrame >= absentLimit)
       ) {
         abortedEarly = true
+        effectiveCount = Math.min(frameCount, processedThrough + 1, Math.max(lastFaceFrame + 1, probeEnd))
       }
     })
 
-    const effectiveCount = abortedEarly ? Math.max(lastFaceFrame + 1, probeEnd) : frameCount
     const trimmedFaces = facesPerFrame.slice(0, effectiveCount)
     const trimmedFrames = frames.slice(0, effectiveCount)
     const trimmedCuts = sceneCuts.filter((c) => c < effectiveCount)
@@ -122,7 +133,11 @@ async function sampleFaceCentres(
         : faces.map((box) => mouthActivity(trimmedFrames[f - 1], trimmedFrames[f], box, MODEL_W, MODEL_H))
     )
 
-    const { centres, switchCuts } = chooseFocusCentres(trimmedFaces, activityPerFrame, trimmedCuts)
+    const { centres: analysedCentres, switchCuts } = chooseFocusCentres(trimmedFaces, activityPerFrame, trimmedCuts)
+    const centres =
+      analysedCentres.length < frameCount
+        ? analysedCentres.concat(new Array<number | null>(frameCount - analysedCentres.length).fill(null))
+        : analysedCentres
     const cuts = [...new Set([...trimmedCuts, ...switchCuts])].sort((a, b) => a - b)
     return { centres, cuts }
   } finally {

--- a/src/main/pipeline/faces.ts
+++ b/src/main/pipeline/faces.ts
@@ -2,7 +2,8 @@ import { readFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
-import type { FocusKeyframe } from '@shared/types'
+import type { FocusKeyframe, ClipContentType, ClipEditState } from '@shared/types'
+import { classifyClipContent, editDefaultsForContentType } from '@shared/contentType'
 import { mapLimit } from './concurrency'
 import { runFfmpeg } from './ffmpeg'
 import { analyzeClipASD } from './asd'
@@ -236,20 +237,30 @@ function trackRun(
   emit(segmentStart)
 }
 
+export interface ClipFocusAnalysis {
+  focusTrack: FocusKeyframe[] | null
+  contentType: ClipContentType
+}
+
 /**
- * Full auto-reframe analysis for one clip. Returns null when the footage has
- * no usable faces (e.g. screencasts) so the UI can fall back to manual focus.
+ * Full auto-reframe analysis for one clip. Returns null focus track when the
+ * footage has no usable faces (e.g. screencasts) so the UI can fall back to
+ * manual / letterbox framing.
  */
 export async function analyzeClipFocus(
   videoPath: string,
   startSec: number,
   endSec: number,
   signal?: AbortSignal
-): Promise<FocusKeyframe[] | null> {
+): Promise<ClipFocusAnalysis> {
+  let faceCoverage = 0
   try {
     const asd = await analyzeClipASD(videoPath, startSec, endSec, signal)
     if (asd) {
-      if (asd.tracks.length === 0) return null
+      faceCoverage = asd.faceFrameRatio
+      if (asd.tracks.length === 0) {
+        return { focusTrack: null, contentType: classifyClipContent(faceCoverage, false) }
+      }
       const { centres, switchCuts } = chooseSpeakerByScores(
         asd.tracks,
         asd.frameCount,
@@ -257,7 +268,11 @@ export async function analyzeClipFocus(
         asd.fps
       )
       const cuts = [...new Set([...asd.sceneCuts, ...switchCuts])].sort((a, b) => a - b)
-      return buildFocusTrack(centres, startSec, cuts, asd.fps)
+      const focusTrack = buildFocusTrack(centres, startSec, cuts, asd.fps)
+      return {
+        focusTrack,
+        contentType: classifyClipContent(faceCoverage, focusTrack !== null)
+      }
     }
   } catch (err) {
     if (signal?.aborted) throw err
@@ -266,10 +281,37 @@ export async function analyzeClipFocus(
 
   try {
     const { centres, cuts } = await sampleFaceCentres(videoPath, startSec, endSec, signal)
-    return buildFocusTrack(centres, startSec, cuts)
+    const detected = centres.filter((c): c is number => c !== null).length
+    faceCoverage = centres.length > 0 ? detected / centres.length : 0
+    const focusTrack = buildFocusTrack(centres, startSec, cuts)
+    return {
+      focusTrack,
+      contentType: classifyClipContent(faceCoverage, focusTrack !== null)
+    }
   } catch (err) {
     if (signal?.aborted) throw err
     console.error('Face analysis failed, falling back to manual focus:', err)
-    return null
+    return { focusTrack: null, contentType: 'screencast' }
+  }
+}
+
+/** Apply screencast-aware layout defaults onto a clip after focus analysis. */
+export function applyFocusAnalysis(
+  clip: {
+    focusTrack: FocusKeyframe[] | null
+    contentType?: ClipContentType | null
+    edit: ClipEditState
+  },
+  analysis: ClipFocusAnalysis
+): void {
+  clip.focusTrack = analysis.focusTrack
+  clip.contentType = analysis.contentType
+  if (analysis.contentType === 'screencast') {
+    clip.edit = editDefaultsForContentType(clip.edit, 'screencast')
+    return
+  }
+  if (analysis.focusTrack) {
+    clip.edit.framing = 'auto'
+    clip.edit.focusX = analysis.focusTrack[0]?.x ?? 0.5
   }
 }

--- a/src/main/pipeline/faces.ts
+++ b/src/main/pipeline/faces.ts
@@ -253,11 +253,10 @@ export async function analyzeClipFocus(
   endSec: number,
   signal?: AbortSignal
 ): Promise<ClipFocusAnalysis> {
-  let faceCoverage = 0
   try {
     const asd = await analyzeClipASD(videoPath, startSec, endSec, signal)
     if (asd) {
-      faceCoverage = asd.faceFrameRatio
+      const faceCoverage = asd.faceFrameRatio
       if (asd.tracks.length === 0) {
         return { focusTrack: null, contentType: classifyClipContent(faceCoverage, false) }
       }
@@ -282,7 +281,7 @@ export async function analyzeClipFocus(
   try {
     const { centres, cuts } = await sampleFaceCentres(videoPath, startSec, endSec, signal)
     const detected = centres.filter((c): c is number => c !== null).length
-    faceCoverage = centres.length > 0 ? detected / centres.length : 0
+    const faceCoverage = centres.length > 0 ? detected / centres.length : 0
     const focusTrack = buildFocusTrack(centres, startSec, cuts)
     return {
       focusTrack,

--- a/src/main/pipeline/faces.ts
+++ b/src/main/pipeline/faces.ts
@@ -85,21 +85,45 @@ async function sampleFaceCentres(
     // Face detection per frame is independent — run inferences concurrently
     // (ONNX Runtime queues session.run calls safely across its thread pool).
     const facesPerFrame: FaceBox[][] = new Array(frameCount).fill(null).map(() => [])
+    let detectionFrames = 0
+    let framesWithFaces = 0
+    let lastFaceFrame = -1
+    let abortedEarly = false
+    const probeEnd = Math.round(8 * SAMPLE_FPS)
+    const absentLimit = Math.round(3 * SAMPLE_FPS)
     await mapLimit(frames, FACE_INFERENCE_CONCURRENCY, async (frame, f) => {
+      if (abortedEarly) return
       signal?.throwIfAborted()
-      facesPerFrame[f] = await detectFaces(frame)
+      const faces = await detectFaces(frame)
+      facesPerFrame[f] = faces
+      detectionFrames++
+      if (faces.length > 0) {
+        framesWithFaces++
+        lastFaceFrame = f
+      }
+      if (
+        (f >= probeEnd && detectionFrames >= probeEnd && framesWithFaces < 3) ||
+        (lastFaceFrame >= 0 && f - lastFaceFrame >= absentLimit)
+      ) {
+        abortedEarly = true
+      }
     })
+
+    const effectiveCount = abortedEarly ? Math.max(lastFaceFrame + 1, probeEnd) : frameCount
+    const trimmedFaces = facesPerFrame.slice(0, effectiveCount)
+    const trimmedFrames = frames.slice(0, effectiveCount)
+    const trimmedCuts = sceneCuts.filter((c) => c < effectiveCount)
 
     // Mouth-movement activity per face — the visual speech signal that lets
     // the focus follow whoever is talking rather than whoever is biggest.
-    const activityPerFrame: number[][] = facesPerFrame.map((faces, f) =>
-      f === 0 || sceneCuts.includes(f)
+    const activityPerFrame: number[][] = trimmedFaces.map((faces, f) =>
+      f === 0 || trimmedCuts.includes(f)
         ? faces.map(() => 0)
-        : faces.map((box) => mouthActivity(frames[f - 1], frames[f], box, MODEL_W, MODEL_H))
+        : faces.map((box) => mouthActivity(trimmedFrames[f - 1], trimmedFrames[f], box, MODEL_W, MODEL_H))
     )
 
-    const { centres, switchCuts } = chooseFocusCentres(facesPerFrame, activityPerFrame, sceneCuts)
-    const cuts = [...new Set([...sceneCuts, ...switchCuts])].sort((a, b) => a - b)
+    const { centres, switchCuts } = chooseFocusCentres(trimmedFaces, activityPerFrame, trimmedCuts)
+    const cuts = [...new Set([...trimmedCuts, ...switchCuts])].sort((a, b) => a - b)
     return { centres, cuts }
   } finally {
     await rm(rawPath, { force: true }).catch(() => undefined)

--- a/src/main/pipeline/faces.ts
+++ b/src/main/pipeline/faces.ts
@@ -256,9 +256,9 @@ export async function analyzeClipFocus(
   try {
     const asd = await analyzeClipASD(videoPath, startSec, endSec, signal)
     if (asd) {
-      const faceCoverage = asd.faceFrameRatio
+      const detectionFaceCoverage = asd.faceFrameRatio
       if (asd.tracks.length === 0) {
-        return { focusTrack: null, contentType: classifyClipContent(faceCoverage, false) }
+        return { focusTrack: null, contentType: classifyClipContent(detectionFaceCoverage, false) }
       }
       const { centres, switchCuts } = chooseSpeakerByScores(
         asd.tracks,
@@ -268,6 +268,8 @@ export async function analyzeClipFocus(
       )
       const cuts = [...new Set([...asd.sceneCuts, ...switchCuts])].sort((a, b) => a - b)
       const focusTrack = buildFocusTrack(centres, startSec, cuts, asd.fps)
+      const detected = centres.filter((c): c is number => c !== null).length
+      const faceCoverage = centres.length > 0 ? detected / centres.length : 0
       return {
         focusTrack,
         contentType: classifyClipContent(faceCoverage, focusTrack !== null)

--- a/src/main/pipeline/index.ts
+++ b/src/main/pipeline/index.ts
@@ -7,7 +7,7 @@ import { mapLimit } from './concurrency'
 import { extractAudioChunks, extractThumbnail, probeVideo } from './ffmpeg'
 import { transcribeChunks } from './transcribe'
 import { detectHighlights } from './highlights'
-import { analyzeClipFocus } from './faces'
+import { analyzeClipFocus, applyFocusAnalysis } from './faces'
 import { annotateEnergy } from './energy'
 import { assessClipVisuals, ensembleScore } from './visualScore'
 import { attachBroll } from './broll'
@@ -228,25 +228,22 @@ export async function analyzeProject(
     project.prompt = options.prompt
     await saveProject(project)
 
-    onProgress({ stage: 'reframe', progress: 0.72, message: 'Tracking faces for auto reframing…' })
+    onProgress({ stage: 'reframe', progress: 0.72, message: 'Analysing layout (faces vs screen share)…' })
     let reframed = 0
     await mapLimit(clips, 2, async (clip) => {
       signal?.throwIfAborted()
-      clip.focusTrack = await analyzeClipFocus(
+      const analysis = await analyzeClipFocus(
         project.video.path,
         clip.suggestedStart,
         clip.suggestedEnd,
         signal
       )
-      if (clip.focusTrack) {
-        clip.edit.framing = 'auto'
-        clip.edit.focusX = clip.focusTrack[0]?.x ?? 0.5
-      }
+      applyFocusAnalysis(clip, analysis)
       reframed++
       onProgress({
         stage: 'reframe',
         progress: 0.72 + (reframed / clips.length) * 0.1,
-        message: 'Tracking faces for auto reframing…'
+        message: 'Analysing layout (faces vs screen share)…'
       })
     })
 

--- a/src/main/pipeline/render.ts
+++ b/src/main/pipeline/render.ts
@@ -15,6 +15,7 @@ import type {
 import type { EncoderPreference } from '@shared/types'
 import { computeKeptSegments, remapTranscript, TimeMap, type KeptSegment } from '@shared/tighten'
 import { focusPanDuration, focusSnaps } from '@shared/focusTrack'
+import { clipAllowsAutoZoom } from '@shared/contentType'
 import { computeZoomEvents, remapZoomEvents, type ZoomEvent } from '@shared/zoom'
 import { runFfmpegWith } from './ffmpeg'
 import { buildAss, fontsDir } from './captions'
@@ -116,6 +117,12 @@ function reframeGraph(clip: Clip, source: VideoInfo, inputLabel: string): string
       `[bg]scale=${w}:${h}:force_original_aspect_ratio=increase,crop=${w}:${h},gblur=sigma=24,eq=brightness=-0.12[bgb];` +
       `[fg]scale=${w}:${h}:force_original_aspect_ratio=decrease:flags=lanczos[fgs];` +
       `[bgb][fgs]overlay=(W-w)/2:(H-h)/2[reframed]`
+    )
+  }
+  if (clip.edit.reframeMode === 'fit-letterbox') {
+    return (
+      `[${inputLabel}]scale=${w}:${h}:force_original_aspect_ratio=decrease:flags=lanczos,` +
+      `pad=${w}:${h}:(ow-iw)/2:(oh-ih)/2:color=black[reframed]`
     )
   }
   // Crop to the target ratio around the horizontal focus point, then scale.
@@ -439,7 +446,7 @@ export async function renderClip(job: RenderJob): Promise<string> {
   // Auto zoom: plan in source time (shared with the preview), then remap to
   // the clip-relative output timeline the filters run on.
   let zoomEvents: ZoomEvent[] | null = null
-  if (clip.edit.autoZoom) {
+  if (clipAllowsAutoZoom(clip.edit)) {
     const planned = computeZoomEvents(transcript, start, clip.edit.end, segments)
     zoomEvents = remapZoomEvents(planned, (t) => (map ? map.toOutput(t) : t - start))
     if (zoomEvents.length === 0) zoomEvents = null

--- a/src/main/projects.ts
+++ b/src/main/projects.ts
@@ -30,6 +30,7 @@ export async function loadProject(id: string): Promise<Project> {
   project.video.hasAudio ??= true
   for (const clip of project.clips) {
     clip.focusTrack ??= null
+    clip.contentType ??= null
     clip.edit.framing ??= 'manual'
     clip.edit.tightenCuts ??= false
     clip.edit.autoZoom ??= false

--- a/src/renderer/src/components/EditorScreen.tsx
+++ b/src/renderer/src/components/EditorScreen.tsx
@@ -160,8 +160,14 @@ export default function EditorScreen(): React.JSX.Element {
             <Toggle
               label="Auto zoom — punch-ins on emphasis, jump zooms covering cuts"
               checked={clip.edit.autoZoom ?? false}
+              disabled={clip.edit.reframeMode !== 'crop'}
               onChange={(v) => set({ autoZoom: v })}
             />
+            {clip.edit.reframeMode !== 'crop' && (
+              <p className="mt-1 text-[10px] leading-relaxed text-zinc-600">
+                Auto zoom is only available with fill (crop) reframing.
+              </p>
+            )}
           </div>
         </Section>
 
@@ -183,10 +189,11 @@ export default function EditorScreen(): React.JSX.Element {
           </div>
           {!cropDisabled && (
             <>
-              <div className="mt-3 grid grid-cols-2 gap-1.5">
+              <div className="mt-3 grid grid-cols-3 gap-1.5">
                 {(
                   [
                     { value: 'crop', label: 'Fill (crop)' },
+                    { value: 'fit-letterbox', label: 'Fit (letterbox)' },
                     { value: 'fit-blur', label: 'Fit + blur' }
                   ] as Array<{ value: ReframeMode; label: string }>
                 ).map((m) => (
@@ -203,6 +210,12 @@ export default function EditorScreen(): React.JSX.Element {
                   </button>
                 ))}
               </div>
+              {clip.contentType === 'screencast' && (
+                <p className="mt-2 text-[11px] leading-relaxed text-zinc-500">
+                  Detected as a screen share or demo — using letterbox fit with no zoom so the
+                  full frame stays visible.
+                </p>
+              )}
               {clip.edit.reframeMode === 'crop' && (
                 <>
                   {clip.focusTrack && (
@@ -773,16 +786,24 @@ function Section({
 function Toggle({
   label,
   checked,
+  disabled = false,
   onChange
 }: {
   label: string
   checked: boolean
+  disabled?: boolean
   onChange: (v: boolean) => void
 }): React.JSX.Element {
   return (
     <button
+      type="button"
+      disabled={disabled}
       onClick={() => onChange(!checked)}
-      className="flex w-full items-center justify-between gap-3 rounded-lg border border-surface-600 px-3 py-2.5 text-left text-xs font-medium text-zinc-300 transition hover:bg-surface-800"
+      className={`flex w-full items-center justify-between gap-3 rounded-lg border border-surface-600 px-3 py-2.5 text-left text-xs font-medium transition ${
+        disabled
+          ? 'cursor-not-allowed text-zinc-600 opacity-60'
+          : 'text-zinc-300 hover:bg-surface-800'
+      }`}
     >
       {label}
       <span

--- a/src/renderer/src/components/PreviewPlayer.tsx
+++ b/src/renderer/src/components/PreviewPlayer.tsx
@@ -4,6 +4,7 @@ import type { Clip, Project, WatermarkPosition } from '@shared/types'
 import { hexToRgba, resolveCaptionStyle } from '@shared/captionStyles'
 import { groupWords, wordsInRange } from '@shared/captionLayout'
 import { computeKeptSegments, TimeMap } from '@shared/tighten'
+import { clipAllowsAutoZoom } from '@shared/contentType'
 import { computeZoomEvents } from '@shared/zoom'
 import { formatTimecode } from '../lib/format'
 import {
@@ -142,10 +143,10 @@ export default function PreviewPlayer({
 
   // Mirrors the export's auto-zoom plan (same shared generator).
   const zoomEvents = useMemo(() => {
-    if (!clip.edit.autoZoom) return null
+    if (!clipAllowsAutoZoom(clip.edit)) return null
     const events = computeZoomEvents(project.transcript, start, end, keptSegments)
     return events.length > 0 ? events : null
-  }, [clip.edit.autoZoom, project.transcript, start, end, keptSegments])
+  }, [clip.edit, project.transcript, start, end, keptSegments])
 
   const src = window.clipforge.mediaUrl(project.video.path)
   const isCrop = clip.edit.aspect !== 'original' && clip.edit.reframeMode === 'crop'

--- a/src/renderer/src/components/ProcessingScreen.tsx
+++ b/src/renderer/src/components/ProcessingScreen.tsx
@@ -7,7 +7,7 @@ const STAGES: Array<{ id: PipelineStage; label: string; icon: React.ElementType 
   { id: 'audio', label: 'Extract audio', icon: FileAudio },
   { id: 'transcribe', label: 'Transcribe speech', icon: AudioLines },
   { id: 'analyze', label: 'Find viral moments', icon: Brain },
-  { id: 'reframe', label: 'Track faces for reframing', icon: ScanFace },
+  { id: 'reframe', label: 'Detect layout (faces vs screen share)', icon: ScanFace },
   { id: 'broll', label: 'Find B-roll images', icon: ImagePlus },
   { id: 'thumbnails', label: 'Create thumbnails', icon: Image }
 ]

--- a/src/shared/contentType.ts
+++ b/src/shared/contentType.ts
@@ -1,0 +1,29 @@
+import type { ClipContentType, ClipEditState } from './types'
+
+/** Face coverage below this is treated as a screencast / demo / slides clip. */
+export const SCREENCAST_FACE_COVERAGE = 0.25
+
+export function classifyClipContent(faceCoverage: number, hasFocusTrack: boolean): ClipContentType {
+  if (!hasFocusTrack || faceCoverage < SCREENCAST_FACE_COVERAGE) return 'screencast'
+  return 'speaker'
+}
+
+/** Layout defaults for demos and screen shares on vertical exports. */
+export function editDefaultsForContentType(
+  edit: ClipEditState,
+  contentType: ClipContentType
+): ClipEditState {
+  if (contentType !== 'screencast') return edit
+  return {
+    ...edit,
+    reframeMode: 'fit-letterbox',
+    framing: 'manual',
+    focusX: 0.5,
+    autoZoom: false
+  }
+}
+
+/** Auto zoom only makes sense on cropped talking-head reframes. */
+export function clipAllowsAutoZoom(edit: ClipEditState): boolean {
+  return (edit.autoZoom ?? false) && edit.reframeMode === 'crop'
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -36,7 +36,10 @@ export interface Transcript {
 export type AspectRatio = '9:16' | '1:1' | '16:9' | 'original'
 
 /** How the source frame is fitted into the target aspect ratio. */
-export type ReframeMode = 'crop' | 'fit-blur'
+export type ReframeMode = 'crop' | 'fit-blur' | 'fit-letterbox'
+
+/** Detected clip content — steers 9:16 layout (crop + zoom vs letterbox). */
+export type ClipContentType = 'speaker' | 'screencast'
 
 /** Auto = follow the AI face track; manual = fixed focusX slider. */
 export type FramingMode = 'auto' | 'manual'
@@ -124,6 +127,11 @@ export interface Clip {
   thumbnailPath: string | null
   /** AI face track for auto reframing; null when no usable faces were found. */
   focusTrack: FocusKeyframe[] | null
+  /**
+   * Whether the clip is mostly a talking head or a screencast/demo/slides.
+   * Set during analysis; null on older projects until re-analysed.
+   */
+  contentType?: ClipContentType | null
   /** AI-suggested image inserts timed to spoken keywords. */
   broll: BrollItem[]
   edit: ClipEditState

--- a/tests/asdBailout.test.ts
+++ b/tests/asdBailout.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { ASD_FPS, shouldAbortFaceDetection, trackCoverageRatio } from '../src/main/pipeline/asd'
+import type { FaceTrack } from '../src/main/pipeline/facetracks'
+import type { FaceBox } from '../src/main/pipeline/speaker'
+
+const box = (cx: number): FaceBox => ({
+  x1: cx - 0.1,
+  y1: 0.3,
+  x2: cx + 0.1,
+  y2: 0.5,
+  score: 0.9
+})
+
+function track(start: number, len: number): FaceTrack {
+  return { start, boxes: Array.from({ length: len }, () => box(0.5)) }
+}
+
+describe('shouldAbortFaceDetection', () => {
+  it('bails after the probe window when no faces were found', () => {
+    const probeEnd = 8 * ASD_FPS
+    expect(shouldAbortFaceDetection(probeEnd - 1, 100, 0, -1)).toBe(false)
+    expect(shouldAbortFaceDetection(probeEnd, 100, 0, -1)).toBe(true)
+  })
+
+  it('keeps scanning when enough faces appear in the probe window', () => {
+    const probeEnd = 8 * ASD_FPS
+    expect(shouldAbortFaceDetection(probeEnd, 100, 3, probeEnd - 25)).toBe(false)
+  })
+
+  it('bails once faces disappear for several seconds (screen share)', () => {
+    const lastFace = 5 * ASD_FPS
+    const absentLimit = 3 * ASD_FPS
+    expect(shouldAbortFaceDetection(lastFace + absentLimit - 1, 50, 20, lastFace)).toBe(false)
+    expect(shouldAbortFaceDetection(lastFace + absentLimit, 50, 20, lastFace)).toBe(true)
+  })
+})
+
+describe('trackCoverageRatio', () => {
+  it('sums coverage across tracks', () => {
+    expect(trackCoverageRatio([track(0, 50), track(80, 20)], 100)).toBe(0.7)
+  })
+
+  it('returns zero for empty tracks', () => {
+    expect(trackCoverageRatio([], 100)).toBe(0)
+  })
+})

--- a/tests/contentType.test.ts
+++ b/tests/contentType.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyClipContent,
+  clipAllowsAutoZoom,
+  editDefaultsForContentType,
+  SCREENCAST_FACE_COVERAGE
+} from '@shared/contentType'
+import type { ClipEditState } from '@shared/types'
+
+const baseEdit = (): ClipEditState => ({
+  aspect: '9:16',
+  reframeMode: 'crop',
+  framing: 'auto',
+  tightenCuts: true,
+  autoZoom: true,
+  focusX: 0.3,
+  captionsEnabled: true,
+  captionStyleId: 'beast',
+  showTitle: false,
+  start: 0,
+  end: 30
+})
+
+describe('classifyClipContent', () => {
+  it('marks sparse faces as screencast', () => {
+    expect(classifyClipContent(0, false)).toBe('screencast')
+    expect(classifyClipContent(SCREENCAST_FACE_COVERAGE - 0.01, true)).toBe('screencast')
+  })
+
+  it('marks sustained faces as speaker', () => {
+    expect(classifyClipContent(SCREENCAST_FACE_COVERAGE, true)).toBe('speaker')
+    expect(classifyClipContent(0.8, true)).toBe('speaker')
+  })
+})
+
+describe('editDefaultsForContentType', () => {
+  it('letterboxes screencasts and disables zoom', () => {
+    const out = editDefaultsForContentType(baseEdit(), 'screencast')
+    expect(out.reframeMode).toBe('fit-letterbox')
+    expect(out.autoZoom).toBe(false)
+    expect(out.framing).toBe('manual')
+    expect(out.focusX).toBe(0.5)
+  })
+
+  it('leaves speaker clips unchanged', () => {
+    const edit = baseEdit()
+    expect(editDefaultsForContentType(edit, 'speaker')).toBe(edit)
+  })
+})
+
+describe('clipAllowsAutoZoom', () => {
+  it('allows zoom only on cropped reframes with auto zoom enabled', () => {
+    expect(clipAllowsAutoZoom({ ...baseEdit(), autoZoom: true, reframeMode: 'crop' })).toBe(true)
+    expect(clipAllowsAutoZoom({ ...baseEdit(), autoZoom: true, reframeMode: 'fit-letterbox' })).toBe(
+      false
+    )
+    expect(clipAllowsAutoZoom({ ...baseEdit(), autoZoom: false, reframeMode: 'crop' })).toBe(false)
+  })
+})

--- a/tests/focusTrack.test.ts
+++ b/tests/focusTrack.test.ts
@@ -82,6 +82,14 @@ describe('buildFocusTrack', () => {
     expect(buildFocusTrack(centres, 0)).toBeNull()
   })
 
+  it('counts a no-face suffix against the focus threshold', () => {
+    const centres: Array<number | null> = [
+      ...Array.from({ length: 6 }, () => 0.4),
+      ...Array.from({ length: 24 }, () => null)
+    ]
+    expect(buildFocusTrack(centres, 0)).toBeNull()
+  })
+
   it('produces a single keyframe for a stable speaker', () => {
     const centres = Array.from({ length: 20 }, () => 0.4)
     const track = buildFocusTrack(centres, 10)

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -123,6 +123,16 @@ describe('buildFilterGraph', () => {
     expect(graph.filterComplex).not.toContain('max(0,min(iw-ow,iw*(')
   })
 
+  it('letterboxes wide footage with black bars for screencasts', () => {
+    const clip = makeClip()
+    clip.edit.reframeMode = 'fit-letterbox'
+    const graph = buildFilterGraph(clip, source, null, 30, null)
+    expect(graph.filterComplex).toContain('force_original_aspect_ratio=decrease')
+    expect(graph.filterComplex).toContain('pad=1080:1920')
+    expect(graph.filterComplex).toContain('color=black[reframed]')
+    expect(graph.filterComplex).not.toContain('perspective=')
+  })
+
   it('applies auto zoom via the subpixel perspective filter, not zoompan', () => {
     const graph = buildFilterGraph(makeClip(), source, null, 30, null, {
       zoomEvents: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Product demos and screen recordings were getting stuck on face tracking (scanning at 25 fps even when there were no faces), and when they did finish, 9:16 export would **crop** the screen — showing only part of the UI — with auto zoom on top.

## Fix

### Fast bailout (no faces)
- Stop face detection after ~8s with no faces, or once faces disappear for ~3s (Zoom intro → screen share)
- Skip heavy ASD scoring when track coverage is too low

### Screencast detection + letterbox layout
- Classify each clip as **`speaker`** or **`screencast`** from face-detection coverage
- Screencasts automatically get:
  - **`fit-letterbox`** reframing — full frame scaled to fit with **black bars** (no crop)
  - **Auto zoom off** — zoom only applies to cropped talking-head reframes
  - Manual centred framing (no face-tracking crop)

### Editor
- New **Fit (letterbox)** layout option alongside Fill (crop) and Fit + blur
- Note when AI detected a screen share/demo
- Auto zoom toggle disabled when not using crop mode

## Testing
- `npm test` — 180 tests pass
- `npm run typecheck` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d72e6b1-e26e-41c0-b842-b2290e70adda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d72e6b1-e26e-41c0-b842-b2290e70adda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

