### PR TITLE
Fix B-roll freezing the app on restricted networks

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,17 @@ import { registerIpcHandlers } from './ipc'
 import { isMediaPathAllowed, serveMediaFile } from './mediaAccess'
 import { initialWindowSize, MIN_WINDOW } from './windowSize'
 
+// Backstop: a stray rejection or throw in a background task (pipeline stages,
+// network calls) would otherwise take the whole app down by Node's default.
+// Log it and keep running — individual features already surface their own
+// errors to the renderer.
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection:', reason)
+})
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught exception:', err)
+})
+
 function appIconPath(): string {
   return app.isPackaged
     ? join(process.resourcesPath, 'icon.png')

--- a/src/main/pipeline/imagesearch.ts
+++ b/src/main/pipeline/imagesearch.ts
@@ -1,6 +1,6 @@
 import { writeFile, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
-import { withRetries } from './openai'
+import { withRetries, withTimeout } from './openai'
 
 /**
  * Keyless image search for B-roll. Wikipedia's page-image API is tried first —
@@ -11,6 +11,12 @@ import { withRetries } from './openai'
  */
 
 const USER_AGENT = 'ClipForge/0.1 (open-source video clipper; https://github.com/clipforge)'
+
+// Without a timeout, a request a corporate firewall silently drops hangs forever
+// and freezes the whole B-roll stage. Fail fast instead so the clip just skips
+// its image inserts. Downloads get longer as the payload is larger.
+const SEARCH_TIMEOUT_MS = 15_000
+const DOWNLOAD_TIMEOUT_MS = 30_000
 
 export interface FoundImage {
   imageUrl: string
@@ -47,7 +53,7 @@ async function lookupWikipediaTitle(title: string, signal?: AbortSignal): Promis
   })
   const res = await fetch(`https://en.wikipedia.org/w/api.php?${params}`, {
     headers: { 'User-Agent': USER_AGENT },
-    signal
+    signal: withTimeout(SEARCH_TIMEOUT_MS, signal)
   })
   if (!res.ok) return null
   const data = (await res.json()) as WikiQueryResponse
@@ -81,7 +87,7 @@ async function searchWikipedia(query: string, signal?: AbortSignal): Promise<Fou
   })
   const res = await fetch(`https://en.wikipedia.org/w/api.php?${params}`, {
     headers: { 'User-Agent': USER_AGENT },
-    signal
+    signal: withTimeout(SEARCH_TIMEOUT_MS, signal)
   })
   if (!res.ok) return null
   const data = (await res.json()) as WikiQueryResponse
@@ -120,7 +126,7 @@ async function searchOpenverse(query: string, signal?: AbortSignal): Promise<Fou
   })
   const res = await fetch(`https://api.openverse.org/v1/images/?${params}`, {
     headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
-    signal
+    signal: withTimeout(SEARCH_TIMEOUT_MS, signal)
   })
   if (!res.ok) return null
   const data = (await res.json()) as OpenverseResponse
@@ -170,7 +176,10 @@ export async function downloadImage(
   try {
     return await withRetries(
       async () => {
-        const res = await fetch(imageUrl, { headers: { 'User-Agent': USER_AGENT }, signal })
+        const res = await fetch(imageUrl, {
+          headers: { 'User-Agent': USER_AGENT },
+          signal: withTimeout(DOWNLOAD_TIMEOUT_MS, signal)
+        })
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         const type = res.headers.get('content-type') ?? ''
         if (!type.startsWith('image/')) throw new Error(`not an image: ${type}`)

--- a/src/main/pipeline/openai.ts
+++ b/src/main/pipeline/openai.ts
@@ -71,6 +71,16 @@ function isNonRetryable(err: unknown): boolean {
   )
 }
 
+/**
+ * Combine an optional caller cancel signal with a hard timeout, so a connection
+ * a firewall silently blackholes aborts instead of hanging the request forever
+ * (fetch has no default timeout). Returns a signal that fires on either.
+ */
+export function withTimeout(ms: number, signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(ms)
+  return signal ? AbortSignal.any([signal, timeout]) : timeout
+}
+
 export interface RetryOptions {
   attempts?: number
   baseDelayMs?: number

--- a/src/main/pipeline/render.ts
+++ b/src/main/pipeline/render.ts
@@ -1,4 +1,5 @@
 import { writeFile, mkdir, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
@@ -305,6 +306,9 @@ export function buildFilterGraph(
     (b) =>
       b.enabled &&
       b.imagePath !== null &&
+      // A downloaded image can go missing (project folder moved, cache cleared);
+      // handing a non-existent path to ffmpeg would fail the whole export.
+      existsSync(b.imagePath) &&
       b.end > clip.edit.start &&
       b.start < clip.edit.end
   )


### PR DESCRIPTION
## Problem

Users reported the app "crashing" during clip generation when the **AI B-roll** option is enabled. The symptom is the app freezing indefinitely at the *"Finding B-roll images…"* stage (progress 0.82).

## Root cause

The B-roll stage is the only part of generation that reaches hosts other than the OpenAI API — `en.wikipedia.org`, `api.openverse.org`, and arbitrary image CDNs (`imagesearch.ts`). Every one of those `fetch` calls passed only the caller's cancel signal and **no timeout**.

`fetch` has no default timeout. On a restricted/corporate network these hosts are commonly **silently blackholed** (the connection is neither accepted nor refused), so the request never resolves *and* never rejects. The stage hangs forever. The existing per-clip `try/catch` (`pipeline/index.ts`) cannot help, because a hang is not an exception.

## Changes

- **Add `withTimeout()`** (`pipeline/openai.ts`) combining the cancel signal with `AbortSignal.timeout`, and apply it to all four image-search/download fetches (15s for API lookups, 30s for downloads). A blocked host now fails fast and the clip simply skips its inserts — generation continues.
- **Guard B-roll images with `existsSync`** before handing them to ffmpeg on export (`pipeline/render.ts`), mirroring the branding watermark. A moved/deleted image no longer fails the whole export.
- **Add `unhandledRejection` / `uncaughtException` handlers** in `main/index.ts` as a backstop, so a stray background error logs instead of taking the app down (Node's default).

## Testing

- `npm run typecheck` — clean
- `npm test` — 189/189 pass

## Note

I could not reproduce the freeze locally, so I can't be 100% certain this is the exact fault every affected user hit, but it is the most plausible cause on a restricted network and the changes are strict robustness improvements regardless. The new `console.error` handlers will surface anything else in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive timeouts and file checks on B-roll paths; global exception handlers only log and do not change user-facing error paths for normal flows.
> 
> **Overview**
> Fixes **B-roll generation hanging indefinitely** on restricted networks where Wikipedia, Openverse, and CDN `fetch` calls had no timeout. A new **`withTimeout()`** helper merges caller cancel signals with `AbortSignal.timeout` and is applied to all image-search API calls (**15s**) and downloads (**30s**), so blocked hosts fail fast and clips can skip inserts while generation continues.
> 
> **Export** now checks **`existsSync`** on each enabled B-roll `imagePath` before passing it to ffmpeg, so moved or deleted cached images no longer fail the whole render.
> 
> The **Electron main process** registers **`unhandledRejection`** and **`uncaughtException`** handlers that log and keep the app running instead of exiting on stray background failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c0167f172f2f71e11b706db3940e1873cbb55ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->