### PR TITLE
Fix dev-update black screen, OpenAI hangs, and lost-edit races

### DIFF
--- a/src/main/fonts.ts
+++ b/src/main/fonts.ts
@@ -102,7 +102,7 @@ export async function addCustomFonts(paths: string[]): Promise<CustomFont[]> {
     if (!FONT_EXTENSIONS.has(extname(path).toLowerCase())) continue
     const font = await fontFromFile(path)
     if (!font) continue
-    // userData paths are implicitly allowed by the media:// allowlist.
+    // userData/fonts is one of the media:// allowlisted directories.
     await copyFile(path, join(dir, basename(path)))
   }
   return listCustomFonts()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -31,7 +31,7 @@ import { clearImportCookiesFile, installImportCookiesFile } from './cookies'
 import { checkForUpdates, downloadUpdate, installUpdate, updateFromSource } from './updates'
 import { isMediaPathAllowed } from './mediaAccess'
 import { sanitizeFileName, uniqueOutputPath } from './exportPath'
-import { deleteProject, listProjects, loadProject, saveProject } from './projects'
+import { deleteProject, listProjects, loadProject, updateProject } from './projects'
 import {
   getApiKey,
   getBrandingSettings,
@@ -146,35 +146,32 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('project:delete', async (_e, id: string) => deleteProject(id))
 
   ipcMain.handle('project:updateClip', async (_e, projectId: string, clip: Clip) => {
-    const project = await loadProject(projectId)
-    const idx = project.clips.findIndex((c) => c.id === clip.id)
-    if (idx === -1) throw new Error('Clip not found')
-    project.clips[idx] = clip
-    await saveProject(project)
-    return project
+    return updateProject(projectId, (project) => {
+      const idx = project.clips.findIndex((c) => c.id === clip.id)
+      if (idx === -1) throw new Error('Clip not found')
+      project.clips[idx] = clip
+    })
   })
 
   ipcMain.handle('project:rename', async (_e, projectId: string, name: string) => {
-    const project = await loadProject(projectId)
-    project.name = name.trim() || project.name
-    await saveProject(project)
-    return project
+    return updateProject(projectId, (project) => {
+      project.name = name.trim() || project.name
+    })
   })
 
   ipcMain.handle(
     'project:updateTranscriptWord',
     async (_e, projectId: string, segmentId: number, wordIndex: number, text: string) => {
-      const project = await loadProject(projectId)
-      const segment = project.transcript?.segments.find((s) => s.id === segmentId)
-      const word = segment?.words[wordIndex]
-      if (!segment || !word) throw new Error('Transcript word not found')
-      word.text = text.trim()
-      segment.text = segment.words
-        .map((w) => w.text)
-        .filter((t) => t.length > 0)
-        .join(' ')
-      await saveProject(project)
-      return project
+      return updateProject(projectId, (project) => {
+        const segment = project.transcript?.segments.find((s) => s.id === segmentId)
+        const word = segment?.words[wordIndex]
+        if (!segment || !word) throw new Error('Transcript word not found')
+        word.text = text.trim()
+        segment.text = segment.words
+          .map((w) => w.text)
+          .filter((t) => t.length > 0)
+          .join(' ')
+      })
     }
   )
 
@@ -191,10 +188,10 @@ export function registerIpcHandlers(): void {
           'pick the same video.'
       )
     }
-    project.video = video
-    project.sourceMissing = false
-    await saveProject(project)
-    return project
+    return updateProject(projectId, (fresh) => {
+      fresh.video = video
+      fresh.sourceMissing = false
+    })
   })
 
   ipcMain.handle('clip:export', async (event, projectId: string, opts: ExportOptions) => {
@@ -260,9 +257,13 @@ export function registerIpcHandlers(): void {
       clip,
       project.transcript
     )
-    clip.caption = caption
-    await saveProject(project)
-    return project
+    // Graft only the caption under the lock: edits made while the LLM ran
+    // must survive, so never save the pre-call project object.
+    return updateProject(projectId, (fresh) => {
+      const target = fresh.clips.find((c) => c.id === clipId)
+      if (!target) throw new Error('Clip not found')
+      target.caption = caption
+    })
   })
 
   ipcMain.handle('workvivo:generateCaption', async (_e, projectId: string, clipId: string) => {
@@ -278,9 +279,12 @@ export function registerIpcHandlers(): void {
       project.transcript,
       getBrandVoiceSettings()
     )
-    clip.workvivoCaption = caption
-    await saveProject(project)
-    return project
+    // Same graft-under-lock pattern as clip:generateCaption above.
+    return updateProject(projectId, (fresh) => {
+      const target = fresh.clips.find((c) => c.id === clipId)
+      if (!target) throw new Error('Clip not found')
+      target.workvivoCaption = caption
+    })
   })
 
   ipcMain.handle('workvivo:testConnection', async () => {

--- a/src/main/mediaAccess.ts
+++ b/src/main/mediaAccess.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
-import { extname, resolve, sep } from 'node:path'
+import { extname, join, resolve, sep } from 'node:path'
 import { Readable } from 'node:stream'
 import type { ReadableStream as WebReadableStream } from 'node:stream/web'
 import { app } from 'electron'
@@ -20,16 +20,34 @@ export function allowMediaPath(path: string): void {
 }
 
 /**
- * The renderer may only read files the app has a reason to show it: anything
- * inside userData (thumbnails, B-roll images, downloaded source videos) plus
- * user-selected source videos elsewhere on disk, registered explicitly when a
- * project is created or loaded.
+ * userData subdirectories the renderer has a legitimate reason to read:
+ * project media (thumbnails, B-roll images, downloaded source videos),
+ * custom caption fonts, the branding logo and cached timeline strips.
+ * Deliberately NOT the whole of userData — settings.json (API keys, the
+ * WorkVivo token) and cookies/import-cookies.txt (live session cookies)
+ * live there too and must never be reachable over media://.
+ */
+const USER_DATA_MEDIA_DIRS = ['projects', 'fonts', 'branding', 'timeline-cache'] as const
+
+/** Pure core of the allowlist check. Exported for tests. */
+export function isMediaPathAllowedIn(
+  userData: string,
+  allowed: ReadonlySet<string>,
+  path: string
+): boolean {
+  const full = resolve(path)
+  if (allowed.has(full)) return true
+  return USER_DATA_MEDIA_DIRS.some((dir) => full.startsWith(join(userData, dir) + sep))
+}
+
+/**
+ * The renderer may only read files the app has a reason to show it: the
+ * media subdirectories of userData above, plus user-selected source videos
+ * elsewhere on disk, registered explicitly when a project is created or
+ * loaded.
  */
 export function isMediaPathAllowed(path: string): boolean {
-  const full = resolve(path)
-  if (allowedFiles.has(full)) return true
-  const userData = resolve(app.getPath('userData'))
-  return full === userData || full.startsWith(userData + sep)
+  return isMediaPathAllowedIn(resolve(app.getPath('userData')), allowedFiles, path)
 }
 
 const MIME_TYPES: Record<string, string> = {

--- a/src/main/pipeline/encoders.ts
+++ b/src/main/pipeline/encoders.ts
@@ -202,7 +202,9 @@ export async function downloadGpuFfmpeg(
   const binDir = join(userDataDir(), 'bin')
   await mkdir(binDir, { recursive: true })
   const archivePath = join(tmpdir(), `clipforge-ffmpeg-gpu${url.endsWith('.zip') ? '.zip' : '.tar.xz'}`)
-  const extractDir = join(tmpdir(), 'clipforge-ffmpeg-gpu-extract')
+  // Extract next to the destination: rename() below cannot cross filesystems
+  // (EXDEV), and /tmp is commonly tmpfs on Linux while userData is not.
+  const extractDir = join(binDir, '.extract')
   await rm(extractDir, { recursive: true, force: true })
   await mkdir(extractDir, { recursive: true })
 

--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -603,6 +603,7 @@ async function requestHighlights(
     }
   }
   const sentenceStarts = sentenceStartTimes(transcript)
+  const sentenceEnds = sentenceEndTimes(transcript)
   const maxDur = maxDurationFor(options.clipLength)
   const normalizeEnd = (start: number, end: number): number =>
     normalizeClipEnd(start, end, transcript, videoDurationSec, {
@@ -634,7 +635,7 @@ async function requestHighlights(
     // that lands within the cap.
     if (end - start > maxDur) {
       const capTarget = start + maxDur
-      const lastSentenceEnd = [...sentenceEndTimes(transcript)]
+      const lastSentenceEnd = [...sentenceEnds]
         .reverse()
         .find((e) => e + END_POST_ROLL_SEC <= capTarget && e > start + MIN_CLIP_SEC)
       end =

--- a/src/main/pipeline/index.ts
+++ b/src/main/pipeline/index.ts
@@ -27,7 +27,7 @@ import {
   type CookieAuthOptions
 } from './ytdlp'
 import { getApiKey, getImportPreferences, getModelPreferences } from '../settings'
-import { projectDir, saveProject } from '../projects'
+import { projectDir, saveProject, updateProject } from '../projects'
 
 export async function createProject(videoPath: string): Promise<Project> {
   const video = await probeVideo(videoPath)
@@ -181,8 +181,12 @@ export async function analyzeProject(
       onProgress({ stage: 'transcribe', progress: 0.56, message: 'Measuring vocal energy…' })
       await annotateEnergy(transcript, chunks)
       // Checkpoint: transcription is the most expensive stage, never redo it.
+      // Persist only the fields this pipeline owns — saving the whole local
+      // object would revert e.g. a rename that landed since it was loaded.
       project.transcript = transcript
-      await saveProject(project)
+      await updateProject(project.id, (p) => {
+        p.transcript = transcript
+      })
     } else {
       onProgress({ stage: 'transcribe', progress: 0.56, message: 'Using saved transcript…' })
     }
@@ -230,7 +234,11 @@ export async function analyzeProject(
     project.clips = clips
     project.prompt = options.prompt
     project.videoType = options.videoType
-    await saveProject(project)
+    await updateProject(project.id, (p) => {
+      p.clips = clips
+      p.prompt = options.prompt
+      p.videoType = options.videoType
+    })
 
     onProgress({ stage: 'reframe', progress: 0.72, message: 'Analysing layout (faces vs screen share)…' })
     let reframed = 0
@@ -278,7 +286,9 @@ export async function analyzeProject(
           message: 'Finding B-roll images…'
         })
       })
-      await saveProject(project)
+      await updateProject(project.id, (p) => {
+        p.clips = clips
+      })
     }
 
     onProgress({ stage: 'thumbnails', progress: 0.9, message: 'Creating thumbnails…' })
@@ -300,9 +310,13 @@ export async function analyzeProject(
       })
     }
 
-    await saveProject(project)
+    // Final save returns the freshest merged copy (clips from this run plus
+    // anything — like a rename — that changed on disk while it ran).
+    const persisted = await updateProject(project.id, (p) => {
+      p.clips = clips
+    })
     onProgress({ stage: 'done', progress: 1, message: 'Done' })
-    return project
+    return persisted
   } finally {
     await rm(workDir, { recursive: true, force: true }).catch(() => undefined)
   }

--- a/src/main/pipeline/openai.ts
+++ b/src/main/pipeline/openai.ts
@@ -81,6 +81,16 @@ export function withTimeout(ms: number, signal?: AbortSignal): AbortSignal {
   return signal ? AbortSignal.any([signal, timeout]) : timeout
 }
 
+/**
+ * Per-attempt request timeouts. Every fetch in this module must carry one:
+ * on a restricted network a silently blackholed connection otherwise hangs
+ * the pipeline (or a caption button) forever, and the retry loop never fires
+ * because the fetch never rejects. Each retry gets a fresh window.
+ * Transcription uploads ~7 MB per chunk, so it gets more headroom.
+ */
+export const CHAT_TIMEOUT_MS = 5 * 60_000
+export const TRANSCRIBE_TIMEOUT_MS = 10 * 60_000
+
 export interface RetryOptions {
   attempts?: number
   baseDelayMs?: number
@@ -178,7 +188,7 @@ export async function transcribeAudioFile(
         method: 'POST',
         headers: { Authorization: `Bearer ${apiKey}` },
         body: form,
-        signal: opts.signal
+        signal: withTimeout(TRANSCRIBE_TIMEOUT_MS, opts.signal)
       })
       await raiseForStatus(res, 'Transcription')
       return (await res.json()) as WhisperResponse
@@ -220,7 +230,7 @@ export async function chatJSON<T>(
             json_schema: { name: schemaName, strict: true, schema }
           }
         }),
-        signal
+        signal: withTimeout(CHAT_TIMEOUT_MS, signal)
       })
       await raiseForStatus(res, 'Analysis')
       const body = (await res.json()) as {

--- a/src/main/pipeline/render.ts
+++ b/src/main/pipeline/render.ts
@@ -485,17 +485,22 @@ export async function renderClip(job: RenderJob): Promise<string> {
   }
 
   try {
-    await runFfmpegWith(resolved.bin, buildArgs(encoderArgs(resolved.kind, quality)), runOpts)
-  } catch (err) {
-    // NVENC can fail at runtime (driver updates, GPU busy, session limits).
-    // Unless the user explicitly demanded GPU, fall back to a CPU encode.
-    if (resolved.kind === 'nvenc' && job.encoder !== 'gpu' && !job.signal?.aborted) {
-      console.error('NVENC render failed, retrying on CPU:', err)
-      await rm(job.outputPath, { force: true }).catch(() => undefined)
-      await runFfmpegWith(resolved.bin, buildArgs(encoderArgs('cpu', quality)), runOpts)
-    } else {
-      throw err
+    try {
+      await runFfmpegWith(resolved.bin, buildArgs(encoderArgs(resolved.kind, quality)), runOpts)
+    } catch (err) {
+      // NVENC can fail at runtime (driver updates, GPU busy, session limits).
+      // Unless the user explicitly demanded GPU, fall back to a CPU encode.
+      if (resolved.kind === 'nvenc' && job.encoder !== 'gpu' && !job.signal?.aborted) {
+        console.error('NVENC render failed, retrying on CPU:', err)
+        await rm(job.outputPath, { force: true }).catch(() => undefined)
+        await runFfmpegWith(resolved.bin, buildArgs(encoderArgs('cpu', quality)), runOpts)
+      } else {
+        throw err
+      }
     }
+  } finally {
+    // One temp .ass per captioned render; never leave them behind.
+    if (assPath) await rm(assPath, { force: true }).catch(() => undefined)
   }
   return job.outputPath
 }

--- a/src/main/projects.ts
+++ b/src/main/projects.ts
@@ -13,7 +13,33 @@ export function projectDir(id: string): string {
   return join(projectsRoot(), id)
 }
 
-export async function saveProject(project: Project): Promise<void> {
+/**
+ * Per-project write lock. Everything that writes project.json goes through
+ * here, so concurrent IPC handlers (a clip edit landing while a caption
+ * generates, a rename during analysis) queue up instead of interleaving
+ * load→mutate→save on the same file and silently dropping each other's
+ * changes. Exported for tests.
+ */
+const projectLocks = new Map<string, Promise<unknown>>()
+
+export async function withProjectLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+  const previous = projectLocks.get(id) ?? Promise.resolve()
+  // Run after the predecessor settles, whether it succeeded or failed.
+  const run = previous.then(fn, fn)
+  const tail = run.then(
+    () => undefined,
+    () => undefined
+  )
+  projectLocks.set(id, tail)
+  try {
+    return await run
+  } finally {
+    // Drop the entry once the queue drains so the map cannot grow forever.
+    if (projectLocks.get(id) === tail) projectLocks.delete(id)
+  }
+}
+
+async function persistProject(project: Project): Promise<void> {
   const dir = projectDir(project.id)
   await mkdir(dir, { recursive: true })
   project.updatedAt = Date.now()
@@ -21,6 +47,30 @@ export async function saveProject(project: Project): Promise<void> {
   // sourceMissing is transient state, recomputed on every load.
   const { sourceMissing: _omit, ...persisted } = project
   await writeFile(join(dir, 'project.json'), JSON.stringify(persisted), 'utf8')
+}
+
+export async function saveProject(project: Project): Promise<void> {
+  await withProjectLock(project.id, () => persistProject(project))
+}
+
+/**
+ * Atomic read-modify-write: load the freshest copy from disk, apply `mutate`,
+ * persist, all under the project's lock. This is the safe way to change a
+ * project in response to user actions — handlers that load once and save a
+ * stale copy later lose whatever happened in between. Keep `mutate` quick
+ * (no network calls) so edits queued behind it stay snappy; a throw inside
+ * `mutate` abandons the write and propagates.
+ */
+export async function updateProject(
+  id: string,
+  mutate: (project: Project) => void | Promise<void>
+): Promise<Project> {
+  return withProjectLock(id, async () => {
+    const project = await loadProject(id)
+    await mutate(project)
+    await persistProject(project)
+    return project
+  })
 }
 
 export async function loadProject(id: string): Promise<Project> {
@@ -44,7 +94,8 @@ export async function loadProject(id: string): Promise<Project> {
 }
 
 export async function deleteProject(id: string): Promise<void> {
-  await rm(projectDir(id), { recursive: true, force: true })
+  // Under the lock so an in-flight save cannot resurrect a deleted project.
+  await withProjectLock(id, () => rm(projectDir(id), { recursive: true, force: true }))
 }
 
 export async function listProjects(): Promise<ProjectSummary[]> {

--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -299,6 +299,17 @@ const npmCmd = 'npm'
 let sourceUpdateRunning = false
 
 /**
+ * True when `git pull --ff-only` fetched nothing. Release discovery
+ * (checkForUpdates) and this checkout's origin are different repositories, so
+ * an announced release can exist before it reaches origin — rebuilding and
+ * relaunching identical code would just re-show the update banner. Exported
+ * for tests.
+ */
+export function isPullNoOp(pullOutput: string): boolean {
+  return /already up[ -]to[ -]date/i.test(pullOutput)
+}
+
+/**
  * The environment a source-update relaunch needs, or null when a plain
  * `app.relaunch()` is safe.
  *
@@ -389,7 +400,13 @@ export async function updateFromSource(onProgress: (p: ImportProgress) => void):
     }
 
     onProgress({ progress: -1, message: 'Pulling the latest code…' })
-    await runStep('git', ['pull', '--ff-only'], root)
+    const pullOutput = await runStep('git', ['pull', '--ff-only'], root)
+    if (isPullNoOp(pullOutput)) {
+      throw new Error(
+        'This checkout is already up to date with its origin, so there is nothing to rebuild. ' +
+          'The new release may not have been pushed to this repository yet — check the release page.'
+      )
+    }
 
     onProgress({ progress: -1, message: 'Installing dependencies…' })
     await runStep(npmCmd, ['install', '--no-audit', '--no-fund'], root)

--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -334,36 +334,48 @@ export function detachedRelaunchEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv |
  * relaunch is fine; inside one we spawn the new instance ourselves, detached so
  * it outlives both this process and the electron-vite parent that is about to
  * exit with it.
+ *
+ * Resolves only in the (unreachable) case where exiting does not end this
+ * process; a failed handover rejects so the caller can surface it.
  */
-function relaunchAfterSourceUpdate(root: string): void {
+function relaunchAfterSourceUpdate(root: string): Promise<void> {
   const env = detachedRelaunchEnv(process.env)
   if (!env) {
     app.relaunch()
     app.exit(0)
-    return
+    return Promise.resolve()
   }
   // spawn reports launch failures on the 'error' event, not by throwing, so the
   // handover waits for 'spawn' before exiting. A failure keeps this instance
   // running: app.relaunch() would inherit ELECTRON_RENDERER_URL and land on the
   // dead dev server, and exiting outright would leave nothing at all.
-  const onFailure = (err: unknown): void => {
-    console.error('Could not relaunch after the update:', err)
-  }
-  try {
-    const child = spawn(process.execPath, [root], {
-      cwd: root,
-      detached: true,
-      stdio: 'ignore',
-      env
-    })
-    child.once('error', onFailure)
-    child.once('spawn', () => {
-      child.unref()
-      app.exit(0)
-    })
-  } catch (err) {
-    onFailure(err)
-  }
+  return new Promise((resolve, reject) => {
+    const onFailure = (err: unknown): void => {
+      reject(
+        new Error(
+          `The update is installed, but ClipForge could not restart itself (${
+            err instanceof Error ? err.message : String(err)
+          }). Quit and start it again to finish.`
+        )
+      )
+    }
+    try {
+      const child = spawn(process.execPath, [root], {
+        cwd: root,
+        detached: true,
+        stdio: 'ignore',
+        env
+      })
+      child.once('error', onFailure)
+      child.once('spawn', () => {
+        child.unref()
+        app.exit(0)
+        resolve()
+      })
+    } catch (err) {
+      onFailure(err)
+    }
+  })
 }
 
 /**
@@ -423,8 +435,11 @@ export async function updateFromSource(onProgress: (p: ImportProgress) => void):
     await runStep(npmCmd, ['run', 'build'], root)
 
     onProgress({ progress: 1, message: 'Restarting…' })
-    // Let the IPC reply and the "Restarting…" frame land before swapping.
-    setTimeout(() => relaunchAfterSourceUpdate(root), 800)
+    // Let the "Restarting…" frame land before swapping. Awaiting the handover
+    // keeps a failed relaunch from resolving as success and stranding the
+    // renderer on that frame with no way to retry.
+    await new Promise((r) => setTimeout(r, 800))
+    await relaunchAfterSourceUpdate(root)
   } finally {
     sourceUpdateRunning = false
   }

--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -299,6 +299,55 @@ const npmCmd = 'npm'
 let sourceUpdateRunning = false
 
 /**
+ * The environment a source-update relaunch needs, or null when a plain
+ * `app.relaunch()` is safe.
+ *
+ * Under `npm run dev` the renderer is served over HTTP from
+ * ELECTRON_RENDERER_URL, and electron-vite exits the moment this process does
+ * (`ps.on('close', process.exit)`), taking that dev server down with it.
+ * `app.relaunch()` re-spawns with the environment inherited, so the new window
+ * pointed at a dead dev server and rendered nothing: the black screen you had to
+ * close before running `npm run dev` again. Stripping the variable makes the
+ * relaunched process load the freshly built `out/renderer/index.html` instead.
+ * Exported for tests.
+ */
+export function detachedRelaunchEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv | null {
+  if (!env.ELECTRON_RENDERER_URL) return null
+  const next = { ...env }
+  delete next.ELECTRON_RENDERER_URL
+  return next
+}
+
+/**
+ * Bring the rebuilt app back. Outside a dev-server session Electron's own
+ * relaunch is fine; inside one we spawn the new instance ourselves, detached so
+ * it outlives both this process and the electron-vite parent that is about to
+ * exit with it.
+ */
+function relaunchAfterSourceUpdate(root: string): void {
+  const env = detachedRelaunchEnv(process.env)
+  if (!env) {
+    app.relaunch()
+    app.exit(0)
+    return
+  }
+  try {
+    const child = spawn(process.execPath, [root], {
+      cwd: root,
+      detached: true,
+      stdio: 'ignore',
+      env
+    })
+    child.unref()
+  } catch (err) {
+    // Nothing left to hand off to; fall back and let the user restart by hand.
+    console.error('Could not relaunch after the update:', err)
+    app.relaunch()
+  }
+  app.exit(0)
+}
+
+/**
  * One-click update for source checkouts: fast-forward the repo, reinstall
  * dependencies, rebuild, then relaunch. Only manifest/build-cache churn is
  * discarded automatically (the classic blocked-pull culprit); real local
@@ -350,10 +399,7 @@ export async function updateFromSource(onProgress: (p: ImportProgress) => void):
 
     onProgress({ progress: 1, message: 'Restarting…' })
     // Let the IPC reply and the "Restarting…" frame land before swapping.
-    setTimeout(() => {
-      app.relaunch()
-      app.exit(0)
-    }, 800)
+    setTimeout(() => relaunchAfterSourceUpdate(root), 800)
   } finally {
     sourceUpdateRunning = false
   }

--- a/src/main/updates.ts
+++ b/src/main/updates.ts
@@ -342,6 +342,13 @@ function relaunchAfterSourceUpdate(root: string): void {
     app.exit(0)
     return
   }
+  // spawn reports launch failures on the 'error' event, not by throwing, so the
+  // handover waits for 'spawn' before exiting. A failure keeps this instance
+  // running: app.relaunch() would inherit ELECTRON_RENDERER_URL and land on the
+  // dead dev server, and exiting outright would leave nothing at all.
+  const onFailure = (err: unknown): void => {
+    console.error('Could not relaunch after the update:', err)
+  }
   try {
     const child = spawn(process.execPath, [root], {
       cwd: root,
@@ -349,13 +356,14 @@ function relaunchAfterSourceUpdate(root: string): void {
       stdio: 'ignore',
       env
     })
-    child.unref()
+    child.once('error', onFailure)
+    child.once('spawn', () => {
+      child.unref()
+      app.exit(0)
+    })
   } catch (err) {
-    // Nothing left to hand off to; fall back and let the user restart by hand.
-    console.error('Could not relaunch after the update:', err)
-    app.relaunch()
+    onFailure(err)
   }
-  app.exit(0)
 }
 
 /**

--- a/tests/mediaAccess.test.ts
+++ b/tests/mediaAccess.test.ts
@@ -1,0 +1,56 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isMediaPathAllowedIn } from '../src/main/mediaAccess'
+
+const userData = join(process.cwd(), 'fake-user-data')
+const none: ReadonlySet<string> = new Set()
+
+describe('isMediaPathAllowedIn', () => {
+  it('allows project media (thumbnails, B-roll, downloaded sources)', () => {
+    expect(
+      isMediaPathAllowedIn(userData, none, join(userData, 'projects', 'p1', 'thumbs', 'c1.jpg'))
+    ).toBe(true)
+    expect(
+      isMediaPathAllowedIn(userData, none, join(userData, 'projects', 'p1', 'source.mp4'))
+    ).toBe(true)
+  })
+
+  it('allows custom fonts, branding and timeline cache', () => {
+    expect(isMediaPathAllowedIn(userData, none, join(userData, 'fonts', 'Anton.ttf'))).toBe(true)
+    expect(isMediaPathAllowedIn(userData, none, join(userData, 'branding', 'logo.png'))).toBe(true)
+    expect(
+      isMediaPathAllowedIn(userData, none, join(userData, 'timeline-cache', 'k', 'f001.jpg'))
+    ).toBe(true)
+  })
+
+  it('allows explicitly registered files outside userData', () => {
+    const video = join(process.cwd(), 'somewhere', 'talk.mp4')
+    expect(isMediaPathAllowedIn(userData, new Set([video]), video)).toBe(true)
+    expect(isMediaPathAllowedIn(userData, none, video)).toBe(false)
+  })
+
+  it('denies secrets living in userData (the reason the list is explicit)', () => {
+    expect(isMediaPathAllowedIn(userData, none, join(userData, 'settings.json'))).toBe(false)
+    expect(
+      isMediaPathAllowedIn(userData, none, join(userData, 'cookies', 'import-cookies.txt'))
+    ).toBe(false)
+  })
+
+  it('denies the userData root and prefix-sibling directories', () => {
+    expect(isMediaPathAllowedIn(userData, none, userData)).toBe(false)
+    // "projects-evil" must not pass a naive startsWith("...projects") check.
+    expect(
+      isMediaPathAllowedIn(userData, none, join(userData, 'projects-evil', 'x.jpg'))
+    ).toBe(false)
+  })
+
+  it('denies traversal out of an allowed directory', () => {
+    expect(
+      isMediaPathAllowedIn(
+        userData,
+        none,
+        join(userData, 'projects', '..', 'settings.json')
+      )
+    ).toBe(false)
+  })
+})

--- a/tests/projects.test.ts
+++ b/tests/projects.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { withProjectLock } from '../src/main/projects'
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+describe('withProjectLock', () => {
+  it('serialises writers on the same project id', async () => {
+    const order: string[] = []
+    const first = withProjectLock('a', async () => {
+      order.push('first-start')
+      await sleep(30)
+      order.push('first-end')
+    })
+    const second = withProjectLock('a', async () => {
+      order.push('second')
+    })
+    await Promise.all([first, second])
+    expect(order).toEqual(['first-start', 'first-end', 'second'])
+  })
+
+  it('does not block writers on other project ids', async () => {
+    const order: string[] = []
+    const slow = withProjectLock('a', async () => {
+      await sleep(30)
+      order.push('a')
+    })
+    const fast = withProjectLock('b', async () => {
+      order.push('b')
+    })
+    await Promise.all([slow, fast])
+    expect(order).toEqual(['b', 'a'])
+  })
+
+  it('releases the lock after a failure and propagates the error', async () => {
+    const failing = withProjectLock('a', async () => {
+      throw new Error('boom')
+    })
+    await expect(failing).rejects.toThrow('boom')
+    // The queue must keep moving after a failed writer.
+    const after = await withProjectLock('a', async () => 'ok')
+    expect(after).toBe('ok')
+  })
+
+  it('returns each writer its own result', async () => {
+    const [x, y] = await Promise.all([
+      withProjectLock('a', async () => 1),
+      withProjectLock('a', async () => 2)
+    ])
+    expect(x).toBe(1)
+    expect(y).toBe(2)
+  })
+})

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   compareVersions,
+  detachedRelaunchEnv,
   evaluateUpdate,
   findGitRoot,
   resolveSourceRepoRoot,
@@ -59,6 +60,29 @@ describe('spawnStepOptions', () => {
     if (process.platform === 'win32') return
     expect(spawnStepOptions('npm', process.cwd()).shell).toBeUndefined()
     expect(spawnStepOptions('git', process.cwd()).shell).toBeUndefined()
+  })
+})
+
+describe('detachedRelaunchEnv', () => {
+  it('drops the dev-server URL so the relaunch loads the rebuilt renderer', () => {
+    const env = detachedRelaunchEnv({
+      ELECTRON_RENDERER_URL: 'http://localhost:5173',
+      PATH: '/usr/bin'
+    })
+    expect(env).not.toBeNull()
+    expect(env!.ELECTRON_RENDERER_URL).toBeUndefined()
+    // Everything else has to survive, or the new process loses its toolchain.
+    expect(env!.PATH).toBe('/usr/bin')
+  })
+
+  it('leaves the original environment untouched', () => {
+    const original = { ELECTRON_RENDERER_URL: 'http://localhost:5173' }
+    detachedRelaunchEnv(original)
+    expect(original.ELECTRON_RENDERER_URL).toBe('http://localhost:5173')
+  })
+
+  it('returns null outside a dev-server session, where app.relaunch works', () => {
+    expect(detachedRelaunchEnv({ PATH: '/usr/bin' })).toBeNull()
   })
 })
 

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -6,6 +6,7 @@ import {
   detachedRelaunchEnv,
   evaluateUpdate,
   findGitRoot,
+  isPullNoOp,
   resolveSourceRepoRoot,
   spawnStepOptions
 } from '../src/main/updates'
@@ -60,6 +61,19 @@ describe('spawnStepOptions', () => {
     if (process.platform === 'win32') return
     expect(spawnStepOptions('npm', process.cwd()).shell).toBeUndefined()
     expect(spawnStepOptions('git', process.cwd()).shell).toBeUndefined()
+  })
+})
+
+describe('isPullNoOp', () => {
+  it('detects the no-op pull in both git phrasings', () => {
+    expect(isPullNoOp('Already up to date.\n')).toBe(true)
+    expect(isPullNoOp('Already up-to-date.\n')).toBe(true) // older git
+  })
+
+  it('treats a fast-forward as a real update', () => {
+    expect(
+      isPullNoOp('Updating 83111f8..abc1234\nFast-forward\n package.json | 2 +-\n')
+    ).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Session's worth of reliability and hardening fixes, found by fixing the updater black screen and then auditing the main process for similar failure classes.

### 1. Black screen after in-app update from a source checkout
`updateFromSource` rebuilt the app then called `app.relaunch()`, which re-spawns with the environment inherited. Under `npm run dev` that environment includes electron-vite's `ELECTRON_RENDERER_URL`, and electron-vite exits the moment the app does, taking the Vite dev server with it. The relaunched window pointed at a dead server and rendered nothing. Now a dev-server session is detected and the rebuilt app is spawned detached with the variable stripped, so it loads the freshly built `out/renderer` bundle. Packaged installs keep using `app.relaunch()`.

### 2. OpenAI requests could hang forever
`withTimeout` existed for exactly this but only the image search used it. `chatJSON` and `transcribeAudioFile` now carry per-attempt timeouts (5/10 min), so a blackholed connection on a restricted network fails into the retry loop instead of hanging the pipeline or leaving a caption button stuck busy until restart. Same failure class as the B-roll freeze fixed in #44.

### 3. Concurrent saves silently lost project edits
Every mutating IPC handler did load → mutate → save on the whole `project.json` with no coordination, so overlapping handlers (a trim edit while a caption generated, a rename during analysis) clobbered each other's writes; the renderer's graft-based state masked the loss until the project was reopened. Added a per-project write lock and atomic `updateProject(id, mutate)`; all mutating handlers use it, slow work stays outside the lock, and the analysis pipeline's checkpoints write only the fields the pipeline owns.

### 4. `media://` served settings.json and session cookies
The allowlist granted the renderer blanket read access to all of `userData`, which includes `settings.json` (OpenAI key, WorkVivo token) and `cookies/import-cookies.txt`. Replaced with the four directories the renderer actually loads media from: `projects`, `fonts`, `branding`, `timeline-cache`. Registered source videos elsewhere on disk keep working.

### 5. Source updates no longer rebuild identical code
If `git pull` fetches nothing (e.g. a checkout whose remote URL predates the repository rename and lags the announced release), the updater now stops with a clear message instead of reinstalling, rebuilding, relaunching and re-showing the update banner.

### 6. Small cleanups
- GPU ffmpeg extracts next to its destination; `rename()` cannot cross filesystems (EXDEV, bites on Linux tmpfs).
- Temp `.ass` caption files are deleted after every export (previously leaked one per captioned render).
- `sentenceEndTimes` computed once per highlight response instead of per over-length clip.

## Testing

- `npm run typecheck`, `npm run lint` clean
- `npm test`: 204 tests pass, 15 new (relaunch env stripping, lock serialisation and failure release, media allowlist allow/deny incl. prefix-sibling and traversal cases, pull no-op detection)
- Built app smoke-tested end to end: home, clips, editor and settings screens all render with thumbnails, source video and preview loading through the tightened allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent exposure (`media://` no longer serves secrets), core project persistence semantics, and update/relaunch behavior; incorrect allowlisting or locking could break media playback or lose edits.
> 
> **Overview**
> Hardens the Electron main process around **updates**, **network hangs**, **concurrent project writes**, and **`media://` exposure**, with smaller pipeline/render fixes.
> 
> **Source updates** no longer relaunch into a dead dev server: when `ELECTRON_RENDERER_URL` is set, the app spawns a detached process with that variable stripped so the rebuilt `out/renderer` loads; relaunch failures reject instead of reporting success. A no-op `git pull` aborts with a clear message instead of rebuilding identical code.
> 
> **OpenAI** chat and transcription requests now use per-attempt timeouts (`CHAT_TIMEOUT_MS` / `TRANSCRIBE_TIMEOUT_MS`) so blackholed connections fail into retries instead of hanging the pipeline or caption actions.
> 
> **Project persistence** adds per-project `withProjectLock` and atomic `updateProject(id, mutate)`; IPC handlers, caption grafting after LLM calls, and analysis checkpoints write only owned fields under the lock so overlapping edits are not lost.
> 
> **`media://`** allowlisting is narrowed from all of `userData` to explicit subdirs (`projects`, `fonts`, `branding`, `timeline-cache`) plus registered source paths, blocking `settings.json` and cookie files; `isMediaPathAllowedIn` is testable.
> 
> Also: GPU ffmpeg extracts beside `userData/bin` to avoid EXDEV on Linux, temp `.ass` files are removed after export, and `sentenceEndTimes` is computed once per highlight pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6deb8e35912c639b82caea5502c109133fca9004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->