### PR TITLE
Core quality pass: sentence-cut clips, exact captions, two-pass loudness, lazy reframe (0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ the [releases page](https://github.com/JeremySNR/clip-forge/releases).
 This project uses [semantic versioning](https://semver.org/), loosely: while
 still pre-1.0, minor bumps carry new features and patch bumps carry fixes.
 
-## [Unreleased]
+## [0.8.0] - 2026-09-06
 
 ### Changed
 
@@ -39,12 +39,18 @@ still pre-1.0, minor bumps carry new features and patch bumps carry fixes.
   up to 1.5 s, cut short by the next group, instead of leaving an empty frame
   on every pause.
 - **Loudness normalisation is two-pass.** Exports measure the clip first and
-  normalise with a single linear gain (true-peak limited only where needed)
-  instead of the single-pass gain rider, which pumped audibly on speech.
-  Falls back to single-pass when the source cannot be measured.
+  apply one linear gain instead of the single-pass gain rider, which pumped
+  audibly on speech: through loudnorm's linear mode when the peaks allow it
+  (with the range target raised to the measured range, which that mode
+  requires), otherwise a plain gain into a true-peak limiter. Falls back to
+  single-pass only when the source cannot be measured.
 
 ### Fixed
 
+- **The "fit under N MB" field could not be cleared or retyped.** It was bound
+  straight to the saved setting, so an empty field snapped back and every
+  keystroke rewrote the settings file. It now edits a draft and commits on
+  blur or Enter.
 - **Exported captions sat higher than the preview.** The ASS style was
   bottom-aligned on the anchor line while the preview centred its block
   there, so two-line captions rendered about half a block too high. Events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ still pre-1.0, minor bumps carry new features and patch bumps carry fixes.
 
 ### Changed
 
+- **Clip boundaries are chosen on sentences.** The model now reads the
+  transcript as one sentence per line (derived from word punctuation, with
+  unpunctuated rambles split at their longest pauses) instead of Whisper's
+  segments, which break mid-sentence, and is told to start and end every clip
+  on a line. The ending and opening reviews work on the same sentences. When
+  a start still lands inside a sentence, the clip opens that sentence rather
+  than skipping to the next; an end inside a sentence completes it.
+- **Tightened clips keep their tails.** Removing pauses used to trim the room
+  after the last word down to 0.3 s, so the export's 0.4 s fade ducked the
+  final syllable. Tightening now keeps 0.7 s after the last word and 0.3 s
+  before the first.
 - **Long videos come back in minutes, not an hour.** Speaker-framing analysis
   (face tracking plus active speaker detection at 25 fps) is the slowest
   per-clip stage by a wide margin. The pipeline now runs it only for the top
@@ -48,6 +59,11 @@ still pre-1.0, minor bumps carry new features and patch bumps carry fixes.
   when the transcript is stitched.
 
 ### Added
+
+- **`scripts/eval-clips.ts`.** Measures clip boundaries on saved projects
+  (mid-sentence opens and closes, clipped or dead-air tails, length spread),
+  and with `--rerun` compares them against fresh detection on the same
+  transcript, so prompt changes can be checked instead of guessed.
 
 - **"Fit under N MB" export.** A size cap in Settings and the editor export
   panel, so clips land under Discord, email or WhatsApp limits. The encoder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ still pre-1.0, minor bumps carry new features and patch bumps carry fixes.
 
 ### Changed
 
+- **Long videos come back in minutes, not an hour.** Speaker-framing analysis
+  (face tracking plus active speaker detection at 25 fps) is the slowest
+  per-clip stage by a wide margin. The pipeline now runs it only for the top
+  tier of clips (the eight highest-scoring, extended to twelve for scores of
+  80 or more) and leaves the rest pending. A pending clip is analysed the
+  moment it is opened in the editor, or before it is exported, and the
+  editor says so while it waits. The analysis uses the clip's current trim,
+  so a clip extended before opening is tracked end to end.
 - **Captions lay out by width, not word count.** Groups are broken into lines
   from a per-style character budget derived from the font's measured glyph
   widths and the output aspect ratio, capped at two lines. The same layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ still pre-1.0, minor bumps carry new features and patch bumps carry fixes.
 
 ## [Unreleased]
 
+### Changed
+
+- **Captions lay out by width, not word count.** Groups are broken into lines
+  from a per-style character budget derived from the font's measured glyph
+  widths and the output aspect ratio, capped at two lines. The same layout
+  feeds the preview and the ASS export (which now carries explicit line
+  breaks with libass wrapping off), so a caption can no longer wrap
+  differently in the file than it did in the editor.
+- **Captions hold briefly after a sentence.** A finished group stays up for
+  up to 1.5 s, cut short by the next group, instead of leaving an empty frame
+  on every pause.
+- **Loudness normalisation is two-pass.** Exports measure the clip first and
+  normalise with a single linear gain (true-peak limited only where needed)
+  instead of the single-pass gain rider, which pumped audibly on speech.
+  Falls back to single-pass when the source cannot be measured.
+
+### Fixed
+
+- **Exported captions sat higher than the preview.** The ASS style was
+  bottom-aligned on the anchor line while the preview centred its block
+  there, so two-line captions rendered about half a block too high. Events
+  are now positioned middle-centre on the anchor.
+- **Whisper hallucinations reached captions and the clip picker.** Segments
+  Whisper itself flags as silence (high no-speech probability with
+  low-confidence text) or as looped output (high compression ratio) are now
+  dropped at stitch time, along with their words, and never primed into the
+  next chunk.
+- **Words with zero or negative duration never lit up in karaoke captions.**
+  Word timings are now made monotonic and given a minimum on-screen duration
+  when the transcript is stitched.
+
 ### Added
 
 - **"Fit under N MB" export.** A size cap in Settings and the editor export

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ npm run lint
 
 Integration test scripts live in `scripts/` (`test-pipeline`, `test-e2e`, `test-quality`, `test-wholevideo`, `test-encoders`, `test-resilience`, `test-broll`, `test-youtube`, `test-asd`, `smoke-test.sh`). See each file's header for what it covers. The e2e ones need `OPENAI_API_KEY`.
 
+To measure clip quality on your own projects, `scripts/eval-clips.ts` reads every saved project and reports how many clips open mid-sentence, cut a sentence off, or trail into dead air, plus the length spread. Add `--rerun` (needs `OPENAI_API_KEY`, a few cents per project, no transcription cost) to re-run clip detection on the saved transcripts with the current prompts and compare, which is how to check a prompt change actually helps:
+
+```bash
+npx tsx --tsconfig tsconfig.node.json scripts/eval-clips.ts --verbose
+```
+
 The bundled active-speaker model (`resources/models/lr-asd-*.onnx`) is exported from the MIT-licensed [LR-ASD](https://github.com/Junhua-Liao/LR-ASD) weights with `scripts/export-asd-onnx.py` (requires Python with `torch`, `onnx`, `onnxruntime`, `python_speech_features`).
 
 ## FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipforge",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipforge",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipforge",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Open-source AI video clipper — turn long videos into viral short clips (an Opus Clip alternative)",
   "main": "out/main/index.js",
   "author": "ClipForge Contributors",

--- a/scripts/eval-clips.ts
+++ b/scripts/eval-clips.ts
@@ -25,6 +25,8 @@ import { join } from 'node:path'
 import {
   analyzeClipBoundaries,
   summarizeBoundaries,
+  TAIL_MAX_SEC,
+  TAIL_MIN_SEC,
   type BoundarySummary,
   type ClipBoundaryReport
 } from '../src/shared/clipMetrics'
@@ -56,8 +58,8 @@ function printClip(clip: Clip, r: ClipBoundaryReport): void {
   const flags = [
     r.startsMidSentence ? 'OPENS MID-SENTENCE' : '',
     r.endsMidSentence ? 'ENDS MID-SENTENCE' : '',
-    r.tailSec !== null && r.tailSec < 0.4 ? 'TAIL CLIPPED' : '',
-    r.tailSec !== null && r.tailSec > 1.5 ? 'DEAD AIR' : ''
+    r.tailSec !== null && r.tailSec < TAIL_MIN_SEC ? 'TAIL CLIPPED' : '',
+    r.tailSec !== null && r.tailSec > TAIL_MAX_SEC ? 'DEAD AIR' : ''
   ].filter(Boolean)
   console.log(
     `    [${String(clip.viralityScore).padStart(2)}] ${r.durationSec.toFixed(1)}s  "${clip.title}"` +

--- a/scripts/eval-clips.ts
+++ b/scripts/eval-clips.ts
@@ -1,0 +1,138 @@
+/**
+ * Clip boundary eval over saved projects.
+ *
+ * The project lives or dies by where its clips start and stop. This script
+ * reads every project in ClipForge's userData (transcript + clips), measures
+ * each AI clip's boundaries against the transcript's sentences and prints a
+ * per-project and overall report: how many clips open mid-sentence, how many
+ * cut a sentence off, how the tails fall (too tight for the audio fade, clean,
+ * or trailing into dead air) and the length distribution.
+ *
+ *   npx tsx --tsconfig tsconfig.node.json scripts/eval-clips.ts [flags] [projectId…]
+ *
+ *   --verbose   print every clip with its opening and closing sentence
+ *   --rerun     also re-run highlight detection on the saved transcript with
+ *               the current prompts (needs OPENAI_API_KEY; a few cents per
+ *               project, no transcription cost) and report the fresh clips
+ *               next to the saved ones — the way to A/B a prompt change.
+ *
+ * Projects live in CLIPFORGE_USER_DATA (default ~/.config/clipforge). Runs
+ * fully offline without --rerun.
+ */
+import { readdir, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import {
+  analyzeClipBoundaries,
+  summarizeBoundaries,
+  type BoundarySummary,
+  type ClipBoundaryReport
+} from '../src/shared/clipMetrics'
+import { transcriptSentences } from '../src/shared/sentences'
+import type { Clip, Project } from '../src/shared/types'
+
+const USER_DATA = process.env.CLIPFORGE_USER_DATA ?? join(homedir(), '.config', 'clipforge')
+const args = process.argv.slice(2)
+const verbose = args.includes('--verbose')
+const rerun = args.includes('--rerun')
+const onlyIds = args.filter((a) => !a.startsWith('--'))
+
+function pct(part: number, whole: number): string {
+  return whole === 0 ? '  -' : `${Math.round((part / whole) * 100)}%`.padStart(4)
+}
+
+function printSummary(label: string, s: BoundarySummary): void {
+  console.log(
+    `  ${label.padEnd(9)} ${String(s.clips).padStart(3)} clips | ` +
+      `mid-sentence start ${pct(s.midSentenceStarts, s.clips)} | ` +
+      `mid-sentence end ${pct(s.midSentenceEnds, s.clips)} | ` +
+      `tail clipped ${pct(s.clippedTails, s.clips)} | ` +
+      `dead air ${pct(s.deadAirTails, s.clips)} | ` +
+      `length med ${s.medianDurationSec.toFixed(0)}s (${s.minDurationSec.toFixed(0)}-${s.maxDurationSec.toFixed(0)})`
+  )
+}
+
+function printClip(clip: Clip, r: ClipBoundaryReport): void {
+  const flags = [
+    r.startsMidSentence ? 'OPENS MID-SENTENCE' : '',
+    r.endsMidSentence ? 'ENDS MID-SENTENCE' : '',
+    r.tailSec !== null && r.tailSec < 0.4 ? 'TAIL CLIPPED' : '',
+    r.tailSec !== null && r.tailSec > 1.5 ? 'DEAD AIR' : ''
+  ].filter(Boolean)
+  console.log(
+    `    [${String(clip.viralityScore).padStart(2)}] ${r.durationSec.toFixed(1)}s  "${clip.title}"` +
+      (flags.length ? `  <- ${flags.join(', ')}` : '')
+  )
+  console.log(`         opens:  ${r.openingSentence ?? '(no words)'}`)
+  console.log(`         closes: ${r.closingSentence ?? '(no words)'}`)
+}
+
+async function main(): Promise<void> {
+  const root = join(USER_DATA, 'projects')
+  const ids = (await readdir(root).catch(() => [] as string[])).filter(
+    (id) => onlyIds.length === 0 || onlyIds.includes(id)
+  )
+  if (ids.length === 0) {
+    console.error(`No projects found under ${root}`)
+    process.exit(1)
+  }
+
+  const allSaved: ClipBoundaryReport[] = []
+  const allFresh: ClipBoundaryReport[] = []
+  for (const id of ids) {
+    let project: Project
+    try {
+      project = JSON.parse(await readFile(join(root, id, 'project.json'), 'utf8')) as Project
+    } catch {
+      continue
+    }
+    if (!project.transcript) continue
+    const sentences = transcriptSentences(project.transcript)
+    const saved = project.clips.filter((c) => c.origin !== 'whole-video')
+    console.log(`\n${project.name}  (${id}, ${sentences.length} sentences, video type ${project.videoType})`)
+    const savedReports = saved.map((c) =>
+      analyzeClipBoundaries(project.transcript!, c.edit.start, c.edit.end, sentences)
+    )
+    allSaved.push(...savedReports)
+    printSummary('saved', summarizeBoundaries(savedReports))
+    if (verbose) saved.forEach((c, i) => printClip(c, savedReports[i]))
+
+    if (rerun) {
+      const apiKey = process.env.OPENAI_API_KEY
+      if (!apiKey) {
+        console.error('  --rerun needs OPENAI_API_KEY')
+        process.exit(1)
+      }
+      const { detectHighlights } = await import('../src/main/pipeline/highlights')
+      const model = process.env.CLIPFORGE_ANALYSIS_MODEL ?? 'gpt-5.4-mini'
+      const fresh = await detectHighlights(
+        apiKey,
+        model,
+        project.transcript,
+        {
+          prompt: project.prompt,
+          clipLength: 'auto',
+          broll: false,
+          hookFirst: false,
+          videoType: project.videoType
+        },
+        project.video.durationSec
+      )
+      const freshReports = fresh.map((c) =>
+        analyzeClipBoundaries(project.transcript!, c.edit.start, c.edit.end, sentences)
+      )
+      allFresh.push(...freshReports)
+      printSummary('rerun', summarizeBoundaries(freshReports))
+      if (verbose) fresh.forEach((c, i) => printClip(c, freshReports[i]))
+    }
+  }
+
+  console.log('\nOverall')
+  printSummary('saved', summarizeBoundaries(allSaved))
+  if (rerun) printSummary('rerun', summarizeBoundaries(allFresh))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/test-pipeline.ts
+++ b/scripts/test-pipeline.ts
@@ -12,7 +12,7 @@ import assert from 'node:assert/strict'
 import { probeVideo, extractAudioChunks, extractThumbnail, runFfmpeg, runBinary, FFPROBE_PATH } from '../src/main/pipeline/ffmpeg'
 import { buildAss } from '../src/main/pipeline/captions'
 import { renderClip } from '../src/main/pipeline/render'
-import { groupWords, wordsInRange } from '../src/shared/captionLayout'
+import { captionLayoutBudget, groupWords, wordsInRange } from '../src/shared/captionLayout'
 import { CAPTION_STYLES } from '../src/shared/captionStyles'
 import type { Clip, Transcript } from '../src/shared/types'
 
@@ -102,8 +102,11 @@ async function main(): Promise<void> {
   const transcript = makeTranscript()
   const words = wordsInRange(transcript, 1, 16)
   assert.ok(words.length > 20, `expected words in range, got ${words.length}`)
-  const groups = groupWords(words, 3)
-  assert.ok(groups.every((g) => g.words.length <= 3))
+  const budget = captionLayoutBudget(CAPTION_STYLES[0], 9 / 16)
+  const groups = groupWords(words, budget)
+  assert.ok(groups.every((g) => g.words.length <= budget.maxWords))
+  assert.ok(groups.every((g) => g.lines.length <= budget.maxLines))
+  assert.ok(groups.every((g) => g.lines.flat().length === g.words.length))
   assert.ok(groups.every((g) => g.end >= g.start))
   console.log(`✓ caption layout: ${words.length} words -> ${groups.length} groups`)
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,12 +12,14 @@ import type {
 } from '@shared/types'
 import { VIDEO_EXTENSIONS } from '@shared/video'
 import { sizeTargetBytesFromMb } from '@shared/uploadBudget'
+import { mergeReframeResult, needsReframe } from '@shared/reframe'
 import { analyzeProject, createProject, createProjectFromUrl } from './pipeline'
 import { captionWholeVideo } from './pipeline/wholeVideo'
 import { downloadGpuFfmpeg } from './pipeline/encoders'
 import { probeVideo } from './pipeline/ffmpeg'
 import { getTimeline } from './pipeline/timeline'
 import { renderClip } from './pipeline/render'
+import { ensureClipReframe } from './pipeline/reframe'
 import { generateSocialCaption } from './pipeline/socialCaption'
 import { addCustomFonts, listCustomFonts, removeCustomFont, renderFontsDir } from './fonts'
 import { clearImportCookiesFile, installImportCookiesFile } from './cookies'
@@ -160,8 +162,17 @@ export function registerIpcHandlers(): void {
     return updateProject(projectId, (project) => {
       const idx = project.clips.findIndex((c) => c.id === clip.id)
       if (idx === -1) throw new Error('Clip not found')
-      project.clips[idx] = clip
+      const saved = project.clips[idx]
+      // The renderer may save a copy it took before a lazy reframe analysis
+      // landed on disk. The analysis result belongs to main: keep it rather
+      // than letting the stale copy erase the focus track.
+      project.clips[idx] =
+        needsReframe(clip) && !needsReframe(saved) ? mergeReframeResult(clip, saved) : clip
     })
+  })
+
+  ipcMain.handle('clip:ensureReframe', async (_e, projectId: string, clipId: string) => {
+    return ensureClipReframe(projectId, clipId)
   })
 
   ipcMain.handle('project:rename', async (_e, projectId: string, name: string) => {
@@ -206,9 +217,10 @@ export function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('clip:export', async (event, projectId: string, opts: ExportOptions) => {
-    const project: Project = await loadProject(projectId)
-    const clip = project.clips.find((c) => c.id === opts.clipId)
-    if (!clip) throw new Error('Clip not found')
+    let project: Project = await loadProject(projectId)
+    const found = project.clips.find((c) => c.id === opts.clipId)
+    if (!found) throw new Error('Clip not found')
+    let clip: Clip = found
     if (project.sourceMissing) {
       throw new Error(`The source video is missing (${project.video.path}). Relink it to export.`)
     }
@@ -222,6 +234,16 @@ export function registerIpcHandlers(): void {
     const controller = new AbortController()
     runningExports.set(clip.id, controller)
     try {
+      // A clip exported straight from the grid may never have been opened,
+      // so its speaker framing has not been analysed yet. Do that first: the
+      // export must frame the clip the way the editor would have shown it.
+      if (needsReframe(clip)) {
+        if (!event.sender.isDestroyed()) {
+          event.sender.send('export:progress', { clipId: clip.id, progress: 0, message: 'Analysing framing…' })
+        }
+        project = await ensureClipReframe(projectId, clip.id, controller.signal)
+        clip = project.clips.find((c) => c.id === opts.clipId) ?? clip
+      }
       const rendered = await renderClip({
         clip,
         source: project.video,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -167,7 +167,9 @@ export function registerIpcHandlers(): void {
       // landed on disk. The analysis result belongs to main: keep it rather
       // than letting the stale copy erase the focus track.
       project.clips[idx] =
-        needsReframe(clip) && !needsReframe(saved) ? mergeReframeResult(clip, saved) : clip
+        needsReframe(clip) && !needsReframe(saved)
+          ? mergeReframeResult(clip, saved, project.videoType)
+          : clip
     })
   })
 

--- a/src/main/pipeline/captions.ts
+++ b/src/main/pipeline/captions.ts
@@ -3,7 +3,14 @@ import { app } from 'electron'
 import type { Transcript, BrandColors } from '@shared/types'
 import { resolveCaptionStyle, type CaptionStyle } from '@shared/captionStyles'
 import type { FontMetrics } from '../fonts'
-import { groupWords, wordsInRange, type WordGroup } from '@shared/captionLayout'
+import {
+  CAPTION_SAFE_WIDTH,
+  captionLayoutBudget,
+  groupDisplayEnd,
+  groupWords,
+  wordsInRange,
+  type WordGroup
+} from '@shared/captionLayout'
 
 /**
  * Bundled caption fonts (Anton, Poppins — OFL licensed) so exports render
@@ -57,24 +64,31 @@ function escapeAss(text: string): string {
 function renderGroupText(group: WordGroup, activeIndex: number, style: CaptionStyle): string {
   const highlight = assColor(style.highlightColor)
   const base = assColor(style.textColor)
-  const parts: string[] = []
-  for (let i = 0; i < group.words.length; i++) {
-    const raw = escapeAss(group.words[i].text)
-    const text = style.uppercase ? raw.toUpperCase() : raw
-    if (i === activeIndex) {
-      const pop = '\\t(0,70,\\fscx109\\fscy109)'
-      if (style.highlightBoxColor) {
-        // Fat outline in the pill colour approximates a rounded label.
-        const pill = assColor(style.highlightBoxColor)
-        parts.push(`{\\c${highlight}\\bord10\\3c${pill}\\fscx100\\fscy100${pop}}${text}{\\r}`)
+  const lines: string[] = []
+  let index = 0
+  for (const line of group.lines) {
+    const parts: string[] = []
+    for (const word of line) {
+      const raw = escapeAss(word.text)
+      const text = style.uppercase ? raw.toUpperCase() : raw
+      if (index === activeIndex) {
+        const pop = '\\t(0,70,\\fscx109\\fscy109)'
+        if (style.highlightBoxColor) {
+          // Fat outline in the pill colour approximates a rounded label.
+          const pill = assColor(style.highlightBoxColor)
+          parts.push(`{\\c${highlight}\\bord10\\3c${pill}\\fscx100\\fscy100${pop}}${text}{\\r}`)
+        } else {
+          parts.push(`{\\c${highlight}\\fscx100\\fscy100${pop}}${text}{\\r}`)
+        }
       } else {
-        parts.push(`{\\c${highlight}\\fscx100\\fscy100${pop}}${text}{\\r}`)
+        parts.push(`{\\c${base}}${text}{\\r}`)
       }
-    } else {
-      parts.push(`{\\c${base}}${text}{\\r}`)
+      index++
     }
+    lines.push(parts.join(' '))
   }
-  return parts.join(' ')
+  // Hard line breaks: the layout decided the lines, libass must not re-wrap.
+  return lines.join('\\N')
 }
 
 /** "#RRGGBB" -> ASS style colour with explicit alpha "&HAA BB GGRR". */
@@ -134,7 +148,13 @@ export interface CaptionOptions {
 export function buildAss(transcript: Transcript, opts: CaptionOptions): string {
   const style = resolveCaptionStyle(opts.styleId, opts.brandColors, opts.fontFamily)
   const fontSize = assFontSize(style.fontScale * opts.height, opts.fontMetrics ?? null)
-  const marginV = Math.round((1 - style.positionY) * opts.height)
+  // Captions are positioned per event with \an5\pos so the block is centred on
+  // the style's anchor line exactly as the preview centres it (translateY -50%).
+  // A bottom-aligned style with MarginV would grow upwards from that line and
+  // sit half a block higher than the preview on every two-line caption.
+  const captionX = Math.round(opts.width / 2)
+  const captionY = Math.round(style.positionY * opts.height)
+  const marginH = Math.round(opts.width * (1 - CAPTION_SAFE_WIDTH) / 2)
   const primary = assStyleColor(style.textColor)
   const outline = assStyleColor(style.outlineColor)
   const brandColors = opts.brandColors
@@ -163,12 +183,12 @@ Title: ClipForge captions
 ScriptType: v4.00+
 PlayResX: ${opts.width}
 PlayResY: ${opts.height}
-WrapStyle: 0
+WrapStyle: 2
 ScaledBorderAndShadow: yes
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Caption,${style.fontFamily},${fontSize},${primary},${primary},${outline},&H80000000,${style.bold ? -1 : 0},0,0,0,100,100,0,0,1,${style.outlineWidth},${style.shadow},2,60,60,${marginV},1
+Style: Caption,${style.fontFamily},${fontSize},${primary},${primary},${outline},&H80000000,${style.bold ? -1 : 0},0,0,0,100,100,0,0,1,${style.outlineWidth},${style.shadow},5,${marginH},${marginH},0,1
 Style: Title,${style.fontFamily},${titleFontSize},${hookText},${hookText},${titleBox},${titleShadowColor},-1,0,0,0,100,100,0,0,3,${titleBoxPad},${titleShadow},8,${titleMarginH},${titleMarginH},${titleMarginV},1
 
 [Events]
@@ -186,22 +206,25 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
   }
 
   const words = wordsInRange(transcript, opts.clipStart, opts.clipEnd)
-  const groups = groupWords(words, style.wordsPerGroup)
+  const groups = groupWords(words, captionLayoutBudget(style, opts.width / opts.height))
+  const anchor = `{\\an5\\pos(${captionX},${captionY})}`
 
-  for (const group of groups) {
+  groups.forEach((group, gi) => {
+    // The finished group holds briefly after its last word (never into the
+    // next group) so pauses do not leave an empty frame.
+    const groupEnd = groupDisplayEnd(groups, gi, opts.clipEnd)
     for (let i = 0; i < group.words.length; i++) {
       const w = group.words[i]
       const start = Math.max(0, w.start - opts.clipStart)
-      // Hold the last word of a group on screen until the group ends to avoid flicker.
       const isLast = i === group.words.length - 1
       const next = group.words[i + 1]
-      const end = Math.min(clipDur, (isLast ? Math.max(w.end, group.end) : next.start) - opts.clipStart)
+      const end = Math.min(clipDur, (isLast ? groupEnd : next.start) - opts.clipStart)
       if (end <= start) continue
       lines.push(
-        `Dialogue: 0,${assTime(start)},${assTime(end)},Caption,,0,0,0,,${renderGroupText(group, i, style)}`
+        `Dialogue: 0,${assTime(start)},${assTime(end)},Caption,,0,0,0,,${anchor}${renderGroupText(group, i, style)}`
       )
     }
-  }
+  })
 
   return header + lines.join('\n') + '\n'
 }

--- a/src/main/pipeline/captions.ts
+++ b/src/main/pipeline/captions.ts
@@ -87,7 +87,8 @@ function renderGroupText(group: WordGroup, activeIndex: number, style: CaptionSt
     }
     lines.push(parts.join(' '))
   }
-  // Hard line breaks: the layout decided the lines, libass must not re-wrap.
+  // Hard line breaks: the layout decided the lines (\\q2 on the event keeps
+  // libass from re-wrapping them).
   return lines.join('\\N')
 }
 
@@ -183,7 +184,7 @@ Title: ClipForge captions
 ScriptType: v4.00+
 PlayResX: ${opts.width}
 PlayResY: ${opts.height}
-WrapStyle: 2
+WrapStyle: 0
 ScaledBorderAndShadow: yes
 
 [V4+ Styles]
@@ -207,7 +208,10 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
   const words = wordsInRange(transcript, opts.clipStart, opts.clipEnd)
   const groups = groupWords(words, captionLayoutBudget(style, opts.width / opts.height))
-  const anchor = `{\\an5\\pos(${captionX},${captionY})}`
+  // \q2 turns libass wrapping off for caption events only: the layout above
+  // decided their lines. The hook title keeps the script's smart wrapping
+  // (WrapStyle 0) because it carries no explicit breaks of its own.
+  const anchor = `{\\an5\\q2\\pos(${captionX},${captionY})}`
 
   groups.forEach((group, gi) => {
     // The finished group holds briefly after its last word (never into the

--- a/src/main/pipeline/ffmpeg.ts
+++ b/src/main/pipeline/ffmpeg.ts
@@ -20,7 +20,13 @@ export interface RunOptions {
   signal?: AbortSignal
 }
 
-export function runBinary(bin: string, args: string[], opts: RunOptions = {}): Promise<string> {
+export interface BinaryOutput {
+  stdout: string
+  stderr: string
+}
+
+/** Like runBinary, but also returns stderr — where ffmpeg filters print their reports. */
+export function runBinaryFull(bin: string, args: string[], opts: RunOptions = {}): Promise<BinaryOutput> {
   return new Promise((resolve, reject) => {
     const child = spawn(bin, args, { windowsHide: true, signal: opts.signal })
     let stdout = ''
@@ -44,10 +50,14 @@ export function runBinary(bin: string, args: string[], opts: RunOptions = {}): P
     })
     child.on('error', reject)
     child.on('close', (code) => {
-      if (code === 0) resolve(stdout)
+      if (code === 0) resolve({ stdout, stderr })
       else reject(new Error(`${bin.split(/[\\/]/).pop()} exited with code ${code}:\n${stderr.slice(-2000)}`))
     })
   })
+}
+
+export async function runBinary(bin: string, args: string[], opts: RunOptions = {}): Promise<string> {
+  return (await runBinaryFull(bin, args, opts)).stdout
 }
 
 export function runFfmpeg(args: string[], opts: RunOptions = {}): Promise<string> {

--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -239,6 +239,9 @@ export function snapClipStart(start: number, sentences: Sentence[], wordStarts: 
   const enclosing = sentenceAt(sentences, start)
   if (enclosing) {
     if (start - enclosing.start <= START_SNAP_SEC) return enclosing.start
+    // Deep inside a long sentence: stay on this thought at the nearest word
+    // rather than skipping ahead to the next sentence, which would drop the
+    // rest of the line the model pointed into.
     return snap(start, wordStarts, 1.5)
   }
   const next = sentences.find((s) => s.start >= start)

--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -237,7 +237,10 @@ function snap(time: number, boundaries: number[], toleranceSec: number): number 
  */
 export function snapClipStart(start: number, sentences: Sentence[], wordStarts: number[]): number {
   const enclosing = sentenceAt(sentences, start)
-  if (enclosing && start - enclosing.start <= START_SNAP_SEC) return enclosing.start
+  if (enclosing) {
+    if (start - enclosing.start <= START_SNAP_SEC) return enclosing.start
+    return snap(start, wordStarts, 1.5)
+  }
   const next = sentences.find((s) => s.start >= start)
   if (next && next.start - start <= START_SNAP_SEC) return next.start
   return snap(start, wordStarts, 1.5)

--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -663,6 +663,9 @@ async function requestHighlights(
       hashtags: (raw.hashtags ?? []).map((h) => h.replace(/^#/, '').toLowerCase()),
       thumbnailPath: null,
       focusTrack: null,
+      // The pipeline analyses the top tier itself and leaves the rest for
+      // the editor/export to pick up (see shared/reframe.ts).
+      reframeStatus: 'pending',
       broll: [],
       edit: {
         aspect: '9:16',

--- a/src/main/pipeline/highlights.ts
+++ b/src/main/pipeline/highlights.ts
@@ -7,7 +7,13 @@ import type {
 } from '@shared/types'
 import { DEFAULT_CAPTION_STYLE_ID } from '@shared/captionStyles'
 import { initialClipEditForVideoType } from '@shared/videoType'
-import { normalizeClipEnd, sentenceEndTimes, sentenceStartTimes } from '@shared/sentences'
+import {
+  normalizeClipEnd,
+  sentenceAt,
+  sentencesInRange,
+  transcriptSentences,
+  type Sentence
+} from '@shared/sentences'
 import { chatJSON } from './openai'
 
 interface RawHighlight {
@@ -133,6 +139,27 @@ function formatTimestamp(sec: number): string {
   return `${sec.toFixed(1)}s`
 }
 
+/**
+ * The transcript as the model sees it: one sentence per line with its start
+ * and end, plus a delivery tag on the most and least energetic lines.
+ * Exported for tests.
+ */
+export function formatTranscriptForModel(sentences: Sentence[]): string {
+  return sentences
+    .map((s) => {
+      const delivery =
+        s.energy === undefined
+          ? ''
+          : s.energy >= 0.8
+            ? ' [delivery: energetic]'
+            : s.energy <= 0.2
+              ? ' [delivery: subdued]'
+              : ''
+      return `[${formatTimestamp(s.start)} - ${formatTimestamp(s.end)}] ${s.text}${delivery}`
+    })
+    .join('\n')
+}
+
 const MIN_CLIP_SEC = 8
 
 /** Breathing room added before the first word of a clip. */
@@ -158,17 +185,17 @@ const SENTENCE_SNAP_SEC = 2.5
  * anger was the single strongest predictor in their model. Berger (2011,
  * Psychological Science) shows induced arousal alone increases sharing.
  */
-const SYSTEM_PROMPT = `You are an expert short-form video editor who selects moments most likely to go viral as standalone vertical clips. You receive the timestamped transcript of a long video. Some lines carry a [delivery: ...] tag measured from the actual audio — "energetic" marks the speaker's most aroused, animated delivery, "subdued" the flattest.
+const SYSTEM_PROMPT = `You are an expert short-form video editor who selects moments most likely to go viral as standalone vertical clips. You receive the transcript of a long video as one sentence per line, each prefixed with the second it starts and the second it ends. Some lines carry a [delivery: ...] tag measured from the actual audio — "energetic" marks the speaker's most aroused, animated delivery, "subdued" the flattest.
 
 Selection rules:
 - Every clip MUST have the shape of a complete micro-video: a HOOK that grabs in the first sentence, a BUILD that develops or escalates it, and an ENDING THAT LANDS. A statement or observation on its own — however interesting — is not a clip.
 - What "lands" depends on the material. A story lands on its resolution or emotional beat. Comedy lands on the punchline. An argument lands on its sharpest, most quotable formulation. A reveal lands on the answer. Practical content lands on the takeaway. A deliberately provocative clip can even land on a pointed question that throws back to the hook. All of these are valid endings.
 - What never lands: trailing setup or scene-setting, context that introduces an idea and stops, the middle of a list, or an aside (ending right after "People were experimenting with ChatGPT for the first time" leaves the thought hanging — the sentence exists to set up whatever comes next). If the beat that completes the thought arrives one or two sentences after the moment you picked, extend the clip to include it.
-- Every clip MUST start at the beginning of a sentence or thought and end at a natural conclusion. Never cut mid-sentence.
+- Every clip MUST start at the beginning of a sentence or thought and end at a natural conclusion. Never cut mid-sentence: a clip's "start" is the start time of the line it opens on and its "end" is the end time of the line it closes on.
 - Prefer moments with a strong hook in the first 3 seconds: bold claims, surprising facts, emotional peaks, controversy, humour, actionable value, or compelling storytelling.
 - Clips must be self-contained: a viewer with zero context must understand them.
 - Do not overlap clips. Order them by virality score, highest first.
-- Use the transcript timestamps precisely; do not invent times outside the video.
+- Use the line timestamps exactly as given; do not invent times outside the video.
 
 Virality scoring rubric (0-99), grounded in sharing research (Berger & Milkman 2012: physiological arousal drives transmission; anger, awe and anxiety are the strongest predictors; sadness suppresses sharing; surprise and practical value independently boost it):
 - Hook strength in the first sentence — curiosity gap, bold claim, or open question (0-30)
@@ -198,6 +225,44 @@ function snap(time: number, boundaries: number[], toleranceSec: number): number 
     }
   }
   return best
+}
+
+/**
+ * Where a clip should open given the moment the model pointed at. The model
+ * works from sentence lines, so its start is normally a sentence start
+ * already; when it is not, prefer opening the sentence the moment falls
+ * inside (the model wanted that thought) over skipping to the next one, and
+ * only fall back to the nearest word boundary deep inside a long sentence.
+ * Exported for tests.
+ */
+export function snapClipStart(start: number, sentences: Sentence[], wordStarts: number[]): number {
+  const enclosing = sentenceAt(sentences, start)
+  if (enclosing && start - enclosing.start <= START_SNAP_SEC) return enclosing.start
+  const next = sentences.find((s) => s.start >= start)
+  if (next && next.start - start <= START_SNAP_SEC) return next.start
+  return snap(start, wordStarts, 1.5)
+}
+
+/**
+ * Where a clip should close given the moment the model pointed at: the end
+ * of the sentence it falls inside when that is near, the end of the sentence
+ * just finished when the moment lands in the pause after it, otherwise the
+ * nearest word end (normalizeClipEnd then completes the sentence). Exported
+ * for tests.
+ */
+export function snapClipEnd(end: number, sentences: Sentence[], wordEnds: number[]): number {
+  const enclosing = sentenceAt(sentences, end)
+  if (enclosing) {
+    if (enclosing.end - end <= SENTENCE_SNAP_SEC) return enclosing.end
+    return snap(end, wordEnds, 1.5)
+  }
+  let previous: Sentence | null = null
+  for (const s of sentences) {
+    if (s.end <= end) previous = s
+    else break
+  }
+  if (previous && end - previous.end <= SENTENCE_SNAP_SEC) return previous.end
+  return snap(end, wordEnds, 1.5)
 }
 
 /** How far the ending review may move a clip's end. */
@@ -305,19 +370,18 @@ async function refineClipEndings(
   signal?: AbortSignal
 ): Promise<Clip[]> {
   if (clips.length === 0) return clips
-  const sentenceEnds = sentenceEndTimes(transcript)
+  const sentences = transcriptSentences(transcript)
+  const sentenceEnds = sentences.map((s) => s.end)
 
   const blocks = clips.map((clip, i) => {
-    const inClip = transcript.segments.filter(
-      (s) => s.end > clip.suggestedStart + 0.2 && s.start < clip.suggestedEnd - 0.2
-    )
+    const inClip = sentencesInRange(sentences, clip.suggestedStart + 0.2, clip.suggestedEnd - 0.2)
     // Tag the closing sentences with end times; earlier text is context only.
     const tail = inClip.slice(-3)
     const head = inClip
       .slice(0, -3)
       .map((s) => s.text)
       .join(' ')
-    const continuation = transcript.segments.filter(
+    const continuation = sentences.filter(
       (s) => s.start >= clip.suggestedEnd - 0.5 && s.start < clip.suggestedEnd + CONTINUATION_SEC
     )
     return [
@@ -446,15 +510,14 @@ async function refineClipStarts(
   signal?: AbortSignal
 ): Promise<Clip[]> {
   if (clips.length === 0) return clips
-  const sentenceStarts = sentenceStartTimes(transcript)
+  const sentences = transcriptSentences(transcript)
+  const sentenceStarts = sentences.map((s) => s.start)
 
   const blocks = clips.map((clip, i) => {
     // Only the first stretch of the clip is eligible to be trimmed, so we show
     // just the opening sentences (plus a little slack) as candidates.
     const openWindowEnd = clip.suggestedStart + MAX_START_ADVANCE_SEC + 5
-    const head = transcript.segments
-      .filter((s) => s.end > clip.suggestedStart + 0.2 && s.start < openWindowEnd)
-      .slice(0, 6)
+    const head = sentencesInRange(sentences, clip.suggestedStart + 0.2, openWindowEnd).slice(0, 6)
     return [
       `Clip ${i} — intended hook: "${clip.hook || clip.title}" (currently starts at ${clip.suggestedStart.toFixed(1)}s):`,
       ...head.map((s) => `  [starts ${s.start.toFixed(1)}s] ${s.text}`)
@@ -551,19 +614,11 @@ async function requestHighlights(
   insist: boolean,
   signal?: AbortSignal
 ): Promise<Clip[]> {
-  const transcriptText = transcript.segments
-    .map((s) => {
-      const delivery =
-        s.energy === undefined
-          ? ''
-          : s.energy >= 0.8
-            ? ' [delivery: energetic]'
-            : s.energy <= 0.2
-              ? ' [delivery: subdued]'
-              : ''
-      return `[${formatTimestamp(s.start)} - ${formatTimestamp(s.end)}] ${s.text}${delivery}`
-    })
-    .join('\n')
+  // One sentence per line. Whisper segments break mid-sentence, and a model
+  // that only sees segment boundaries can only propose segment boundaries;
+  // sentence lines let it cut where a thought actually starts and stops.
+  const sentences = transcriptSentences(transcript)
+  const transcriptText = formatTranscriptForModel(sentences)
 
   const targetCount = targetClipCount(videoDurationSec)
 
@@ -576,7 +631,7 @@ async function requestHighlights(
     options.prompt.trim()
       ? `The creator gave these special instructions, which take priority when choosing moments: "${options.prompt.trim()}"`
       : '',
-    'Transcript (each line prefixed with [start - end] in seconds from the start of the video):',
+    'Transcript, one sentence per line, each prefixed with [start - end] in seconds from the start of the video. Start every clip on the start time of a line and end it on the end time of a line:',
     transcriptText
   ]
     .filter(Boolean)
@@ -602,8 +657,7 @@ async function requestHighlights(
       wordEnds.push(w.end)
     }
   }
-  const sentenceStarts = sentenceStartTimes(transcript)
-  const sentenceEnds = sentenceEndTimes(transcript)
+  const sentenceEnds = sentences.map((s) => s.end)
   const maxDur = maxDurationFor(options.clipLength)
   const normalizeEnd = (start: number, end: number): number =>
     normalizeClipEnd(start, end, transcript, videoDurationSec, {
@@ -619,15 +673,12 @@ async function requestHighlights(
   for (const raw of res.clips ?? []) {
     let start = Math.max(0, Math.min(raw.start, videoDurationSec - 1))
     let end = Math.max(start + 1, Math.min(raw.end, videoDurationSec))
-    // Snap the start onto a sentence beginning so the clip opens on a clean
-    // thought, not mid-sentence, then add a little pre-roll. Falls back to the
-    // nearest word boundary when no sentence start is close enough.
-    const sentenceStart = snap(start, sentenceStarts, START_SNAP_SEC)
-    const snappedStart = sentenceStart !== start ? sentenceStart : snap(start, wordStarts, 1.5)
-    start = Math.max(0, snappedStart - START_PRE_ROLL_SEC)
-    // Rough word snap, then extend to the next punctuated sentence end when the
-    // model (or Whisper segment boundary) stopped mid-thought.
-    end = Math.min(videoDurationSec, snap(end, wordEnds, 1.5) + END_POST_ROLL_SEC)
+    // Open on the sentence the model pointed into (plus a little pre-roll)
+    // so the clip never starts mid-thought.
+    start = Math.max(0, snapClipStart(start, sentences, wordStarts) - START_PRE_ROLL_SEC)
+    // Close on a sentence end, then let normalizeClipEnd complete the thought
+    // when the model stopped deep inside a long sentence.
+    end = Math.min(videoDurationSec, snapClipEnd(end, sentences, wordEnds) + END_POST_ROLL_SEC)
     end = normalizeEnd(start, end)
     // Length is a preference, not a floor: we never pad a complete moment to
     // reach a target length (padding tanks completion rate). We only enforce

--- a/src/main/pipeline/index.ts
+++ b/src/main/pipeline/index.ts
@@ -9,6 +9,7 @@ import { ensureTranscript } from './projectTranscript'
 import { detectHighlights } from './highlights'
 import { analyzeClipFocus, applyFocusAnalysis } from './faces'
 import { shouldAnalyzeFaces } from '@shared/videoType'
+import { selectEagerReframeIds } from '@shared/reframe'
 import { assessClipVisuals, ensembleScore } from './visualScore'
 import { attachBroll } from './broll'
 import {
@@ -209,10 +210,23 @@ export async function analyzeProject(
     })
 
     onProgress({ stage: 'reframe', progress: 0.72, message: 'Analysing layout (faces vs screen share)…' })
-    let reframed = 0
-    await mapLimit(clips, 2, async (clip) => {
-      signal?.throwIfAborted()
-      if (shouldAnalyzeFaces(options.videoType)) {
+    if (!shouldAnalyzeFaces(options.videoType)) {
+      // No face tracking for this video type: the layout is a cheap default,
+      // so every clip gets it now.
+      for (const clip of clips) {
+        applyFocusAnalysis(clip, { focusTrack: null, contentType: 'screencast' }, options.videoType)
+        clip.reframeStatus = 'done'
+      }
+    } else {
+      // Face tracking is the slow stage (tens of seconds of CPU per clip), so
+      // only the top tier is analysed here. The rest stay 'pending' and are
+      // analysed when opened or exported (see pipeline/reframe.ts).
+      const eager = selectEagerReframeIds(clips)
+      const eagerClips = clips.filter((c) => eager.has(c.id))
+      for (const clip of clips) clip.reframeStatus = 'pending'
+      let reframed = 0
+      await mapLimit(eagerClips, 2, async (clip) => {
+        signal?.throwIfAborted()
         const analysis = await analyzeClipFocus(
           project.video.path,
           clip.suggestedStart,
@@ -220,20 +234,18 @@ export async function analyzeProject(
           signal
         )
         applyFocusAnalysis(clip, analysis, options.videoType)
-      } else {
-        applyFocusAnalysis(
-          clip,
-          { focusTrack: null, contentType: 'screencast' },
-          options.videoType
-        )
-      }
-      reframed++
-      onProgress({
-        stage: 'reframe',
-        progress: 0.72 + (reframed / clips.length) * 0.1,
-        message: 'Analysing layout (faces vs screen share)…'
+        clip.reframeStatus = 'done'
+        reframed++
+        onProgress({
+          stage: 'reframe',
+          progress: 0.72 + (reframed / eagerClips.length) * 0.1,
+          message:
+            eagerClips.length < clips.length
+              ? `Analysing layout for the top ${eagerClips.length} clips (${reframed}/${eagerClips.length})…`
+              : 'Analysing layout (faces vs screen share)…'
+        })
       })
-    })
+    }
 
     if (options.broll) {
       onProgress({ stage: 'broll', progress: 0.82, message: 'Finding B-roll images…' })

--- a/src/main/pipeline/loudness.ts
+++ b/src/main/pipeline/loudness.ts
@@ -1,0 +1,123 @@
+import { FFMPEG_PATH, runBinaryFull } from './ffmpeg'
+
+/**
+ * Two-pass loudness normalisation.
+ *
+ * ffmpeg's loudnorm filter has two modes. Given nothing but a target it runs
+ * in "dynamic" mode: a look-ahead gain rider that chases the target through
+ * the clip. On speech that is audible as pumping — quiet asides swell, the
+ * tail of a loud line ducks. Given the input's measured loudness it can
+ * instead apply one linear gain for the whole clip (with true-peak limiting
+ * only where needed), which is transparent. That is what every mastering
+ * chain does and what this module makes the export do: measure first, then
+ * normalise with the measurements.
+ *
+ * Social platforms normalise to about -14 LUFS, so exports master to match.
+ */
+
+export const TARGET_I = -14
+export const TARGET_TP = -1.5
+export const TARGET_LRA = 11
+
+export interface LoudnessStats {
+  inputI: number
+  inputTp: number
+  inputLra: number
+  inputThresh: number
+  targetOffset: number
+}
+
+const TARGETS = `I=${TARGET_I}:TP=${TARGET_TP}:LRA=${TARGET_LRA}`
+
+/** The measurement filter, for a first pass whose output is discarded. */
+export const MEASURE_FILTER = `loudnorm=${TARGETS}:print_format=json`
+
+/**
+ * The normalising filter. With measurements it runs linear (one gain for the
+ * whole clip); without, it falls back to the single-pass dynamic mode. Pure
+ * and exported for tests.
+ */
+export function loudnormFilter(stats: LoudnessStats | null): string {
+  if (!stats) return `loudnorm=${TARGETS}`
+  const f = (v: number): string => v.toFixed(2)
+  return (
+    `loudnorm=${TARGETS}` +
+    `:measured_I=${f(stats.inputI)}:measured_TP=${f(stats.inputTp)}` +
+    `:measured_LRA=${f(stats.inputLra)}:measured_thresh=${f(stats.inputThresh)}` +
+    `:offset=${f(stats.targetOffset)}:linear=true`
+  )
+}
+
+/**
+ * Pull the measurement block out of ffmpeg's stderr. loudnorm prints it as a
+ * JSON object of string values after the encode log; the last `{…}` in the
+ * output is it. Returns null when the block is missing or any value is not a
+ * finite number (silent input reports "-inf"), in which case the caller
+ * should fall back to the single-pass filter. Pure and exported for tests.
+ */
+export function parseLoudnormStats(stderr: string): LoudnessStats | null {
+  const close = stderr.lastIndexOf('}')
+  if (close === -1) return null
+  const open = stderr.lastIndexOf('{', close)
+  if (open === -1) return null
+  let raw: Record<string, unknown>
+  try {
+    raw = JSON.parse(stderr.slice(open, close + 1)) as Record<string, unknown>
+  } catch {
+    return null
+  }
+  const num = (key: string): number | null => {
+    const v = Number(raw[key])
+    return Number.isFinite(v) ? v : null
+  }
+  const inputI = num('input_i')
+  const inputTp = num('input_tp')
+  const inputLra = num('input_lra')
+  const inputThresh = num('input_thresh')
+  const targetOffset = num('target_offset')
+  if (
+    inputI === null ||
+    inputTp === null ||
+    inputLra === null ||
+    inputThresh === null ||
+    targetOffset === null
+  ) {
+    return null
+  }
+  return { inputI, inputTp, inputLra, inputThresh, targetOffset }
+}
+
+/**
+ * Measure the loudness of a span of the source's audio. Failures (no audio
+ * stream, silent input, an odd ffmpeg build) return null so the render can
+ * still proceed with the single-pass filter — measurement improves the
+ * export, it must never block it.
+ */
+export async function measureLoudness(
+  sourcePath: string,
+  startSec: number,
+  durationSec: number,
+  signal?: AbortSignal
+): Promise<LoudnessStats | null> {
+  try {
+    const { stderr } = await runBinaryFull(
+      FFMPEG_PATH,
+      [
+        '-hide_banner',
+        '-nostats',
+        '-ss', startSec.toFixed(3),
+        '-t', durationSec.toFixed(3),
+        '-i', sourcePath,
+        '-vn',
+        '-af', MEASURE_FILTER,
+        '-f', 'null', '-'
+      ],
+      { signal }
+    )
+    return parseLoudnormStats(stderr)
+  } catch (err) {
+    if (signal?.aborted) throw err
+    console.error('Loudness measurement failed; using single-pass normalisation:', err)
+    return null
+  }
+}

--- a/src/main/pipeline/loudness.ts
+++ b/src/main/pipeline/loudness.ts
@@ -33,19 +33,55 @@ const TARGETS = `I=${TARGET_I}:TP=${TARGET_TP}:LRA=${TARGET_LRA}`
 export const MEASURE_FILTER = `loudnorm=${TARGETS}:print_format=json`
 
 /**
- * The normalising filter. With measurements it runs linear (one gain for the
- * whole clip); without, it falls back to the single-pass dynamic mode. Pure
- * and exported for tests.
+ * Most gain the limiter path will apply. A source this quiet is broken
+ * (a muted mic, a wrong track), and pushing it 40 dB only amplifies noise.
+ */
+export const MAX_GAIN_DB = 30
+/**
+ * Ceiling for the limiter path, a little under the true-peak target: the
+ * limiter measures sample peaks, and inter-sample peaks after encoding can
+ * sit a few tenths of a dB above them.
+ */
+const LIMITER_CEILING_DB = -2
+
+/**
+ * The normalising filter.
+ *
+ * With measurements, one linear gain brings the clip to the target. Two ways
+ * to apply it: loudnorm's own linear mode when it will accept the job, and a
+ * plain gain into a true-peak limiter when it will not. loudnorm's linear
+ * mode refuses (and silently reverts to the dynamic gain rider this exists to
+ * avoid) when the source's loudness range exceeds the target range or the
+ * gain would push the true peak over the ceiling — both routine for speech,
+ * so the range target is raised to the measured range (it is a ceiling, not a
+ * compressor setting) and peak-limited sources go through the limiter path.
+ *
+ * Without measurements it falls back to single-pass dynamic mode. Pure and
+ * exported for tests.
  */
 export function loudnormFilter(stats: LoudnessStats | null): string {
   if (!stats) return `loudnorm=${TARGETS}`
   const f = (v: number): string => v.toFixed(2)
-  return (
-    `loudnorm=${TARGETS}` +
-    `:measured_I=${f(stats.inputI)}:measured_TP=${f(stats.inputTp)}` +
-    `:measured_LRA=${f(stats.inputLra)}:measured_thresh=${f(stats.inputThresh)}` +
-    `:offset=${f(stats.targetOffset)}:linear=true`
-  )
+  const gainDb = TARGET_I - stats.inputI
+  const peakAfterGain = stats.inputTp + gainDb
+  if (peakAfterGain <= TARGET_TP) {
+    const lra = Math.max(TARGET_LRA, Math.ceil(stats.inputLra * 10) / 10)
+    return (
+      `loudnorm=I=${TARGET_I}:TP=${TARGET_TP}:LRA=${f(lra)}` +
+      `:measured_I=${f(stats.inputI)}:measured_TP=${f(stats.inputTp)}` +
+      `:measured_LRA=${f(stats.inputLra)}:measured_thresh=${f(stats.inputThresh)}` +
+      `:offset=${f(stats.targetOffset)}:linear=true`
+    )
+  }
+  const gain = Math.min(MAX_GAIN_DB, gainDb)
+  const ceiling = Math.pow(10, LIMITER_CEILING_DB / 20)
+  return `volume=${f(gain)}dB,alimiter=limit=${ceiling.toFixed(4)}:attack=5:release=50:level=false`
+}
+
+/** Which path loudnormFilter takes for a measurement; exported for tests and logs. */
+export function normalisationMode(stats: LoudnessStats | null): 'dynamic' | 'linear' | 'limited' {
+  if (!stats) return 'dynamic'
+  return stats.inputTp + (TARGET_I - stats.inputI) <= TARGET_TP ? 'linear' : 'limited'
 }
 
 /**

--- a/src/main/pipeline/openai.ts
+++ b/src/main/pipeline/openai.ts
@@ -144,6 +144,14 @@ export interface WhisperSegment {
   text: string
   start: number
   end: number
+  /**
+   * Decoder diagnostics Whisper reports per segment. Together they identify
+   * the hallucinations it produces on silence and music — see
+   * `isHallucinatedSegment` in transcribe.ts. Absent on some models.
+   */
+  no_speech_prob?: number
+  avg_logprob?: number
+  compression_ratio?: number
 }
 
 export interface WhisperResponse {

--- a/src/main/pipeline/reframe.ts
+++ b/src/main/pipeline/reframe.ts
@@ -10,13 +10,26 @@ import { loadProject, updateProject } from '../projects'
  * guard, before a clip is exported.
  */
 
-const inFlight = new Map<string, Promise<Project>>()
+interface Run {
+  promise: Promise<Project>
+  controller: AbortController
+  /** Callers still interested in the result; the run aborts only when none are left. */
+  waiters: number
+}
+
+const inFlight = new Map<string, Run>()
 
 /**
  * Run the reframe analysis for one clip if it has not run yet, persist the
  * result and return the fresh project. A no-op (returning the current
- * project) when the clip is already analysed or no longer exists. Concurrent
- * calls for the same clip share one analysis.
+ * project) when the clip is already analysed or no longer exists.
+ *
+ * Concurrent calls for the same clip share one analysis. Each caller's
+ * signal governs only its own interest: an aborted caller stops waiting at
+ * once, but the shared run itself is cancelled only when every caller has
+ * aborted — cancelling an export must not strand an editor that is waiting
+ * on the same clip, and a caller without a signal (the editor) keeps the run
+ * alive.
  *
  * Analyses the clip's *current* trim rather than the AI's suggested range,
  * so a clip the user extended before opening it is tracked end to end.
@@ -27,11 +40,53 @@ export function ensureClipReframe(
   signal?: AbortSignal
 ): Promise<Project> {
   const key = `${projectId}:${clipId}`
-  const existing = inFlight.get(key)
-  if (existing) return existing
-  const run = analyseAndPersist(projectId, clipId, signal).finally(() => inFlight.delete(key))
-  inFlight.set(key, run)
-  return run
+  let run = inFlight.get(key)
+  if (!run) {
+    const controller = new AbortController()
+    const started: Run = {
+      controller,
+      waiters: 0,
+      promise: analyseAndPersist(projectId, clipId, controller.signal).finally(() =>
+        inFlight.delete(key)
+      )
+    }
+    inFlight.set(key, started)
+    run = started
+  }
+  return joinRun(run, signal)
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException('Reframe analysis cancelled', 'AbortError')
+}
+
+function joinRun(run: Run, signal?: AbortSignal): Promise<Project> {
+  if (!signal) {
+    run.waiters++
+    return run.promise
+  }
+  if (signal.aborted) return Promise.reject(abortError(signal))
+  run.waiters++
+  return new Promise<Project>((resolve, reject) => {
+    const onAbort = (): void => {
+      run.waiters--
+      if (run.waiters === 0) run.controller.abort()
+      reject(abortError(signal))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    run.promise.then(
+      (project) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(project)
+      },
+      (err: unknown) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
+    )
+  })
 }
 
 async function analyseAndPersist(
@@ -62,6 +117,6 @@ async function analyseAndPersist(
     const idx = fresh.clips.findIndex((c) => c.id === clipId)
     // Regenerated away while we were analysing: nothing to attach it to.
     if (idx === -1) return
-    fresh.clips[idx] = mergeReframeResult(fresh.clips[idx], analysed)
+    fresh.clips[idx] = mergeReframeResult(fresh.clips[idx], analysed, fresh.videoType)
   })
 }

--- a/src/main/pipeline/reframe.ts
+++ b/src/main/pipeline/reframe.ts
@@ -1,0 +1,67 @@
+import type { Clip, Project } from '@shared/types'
+import { mergeReframeResult, needsReframe } from '@shared/reframe'
+import { shouldAnalyzeFaces } from '@shared/videoType'
+import { analyzeClipFocus, applyFocusAnalysis, type ClipFocusAnalysis } from './faces'
+import { loadProject, updateProject } from '../projects'
+
+/**
+ * On-demand reframe analysis for clips the pipeline left 'pending' (see
+ * shared/reframe.ts). Called when a clip is opened in the editor and, as a
+ * guard, before a clip is exported.
+ */
+
+const inFlight = new Map<string, Promise<Project>>()
+
+/**
+ * Run the reframe analysis for one clip if it has not run yet, persist the
+ * result and return the fresh project. A no-op (returning the current
+ * project) when the clip is already analysed or no longer exists. Concurrent
+ * calls for the same clip share one analysis.
+ *
+ * Analyses the clip's *current* trim rather than the AI's suggested range,
+ * so a clip the user extended before opening it is tracked end to end.
+ */
+export function ensureClipReframe(
+  projectId: string,
+  clipId: string,
+  signal?: AbortSignal
+): Promise<Project> {
+  const key = `${projectId}:${clipId}`
+  const existing = inFlight.get(key)
+  if (existing) return existing
+  const run = analyseAndPersist(projectId, clipId, signal).finally(() => inFlight.delete(key))
+  inFlight.set(key, run)
+  return run
+}
+
+async function analyseAndPersist(
+  projectId: string,
+  clipId: string,
+  signal?: AbortSignal
+): Promise<Project> {
+  const project = await loadProject(projectId)
+  const clip = project.clips.find((c) => c.id === clipId)
+  if (!clip || !needsReframe(clip)) return project
+  if (project.sourceMissing) {
+    throw new Error(
+      `The source video is missing (${project.video.path}). Relink it before framing this clip.`
+    )
+  }
+
+  const analysis: ClipFocusAnalysis = shouldAnalyzeFaces(project.videoType)
+    ? await analyzeClipFocus(project.video.path, clip.edit.start, clip.edit.end, signal)
+    : { focusTrack: null, contentType: 'screencast' }
+
+  // Apply onto a copy: the saved clip may have moved on while the analysis
+  // ran, and mergeReframeResult grafts only the analysis-owned fields.
+  const analysed: Clip = { ...clip, edit: { ...clip.edit } }
+  applyFocusAnalysis(analysed, analysis, project.videoType)
+  analysed.reframeStatus = 'done'
+
+  return updateProject(projectId, (fresh) => {
+    const idx = fresh.clips.findIndex((c) => c.id === clipId)
+    // Regenerated away while we were analysing: nothing to attach it to.
+    if (idx === -1) return
+    fresh.clips[idx] = mergeReframeResult(fresh.clips[idx], analysed)
+  })
+}

--- a/src/main/pipeline/render.ts
+++ b/src/main/pipeline/render.ts
@@ -21,7 +21,7 @@ import { resolveCaptionStyle } from '@shared/captionStyles'
 import { computeZoomEvents, fitZoomEvents, remapZoomEvents, type ZoomEvent } from '@shared/zoom'
 import { planUploadEncode, type UploadEncodePlan } from '@shared/uploadBudget'
 import { FFMPEG_PATH, runFfmpegWith } from './ffmpeg'
-import { loudnormFilter, measureLoudness, type LoudnessStats } from './loudness'
+import { loudnormFilter, measureLoudness, normalisationMode, type LoudnessStats } from './loudness'
 import { buildAss, fontsDir } from './captions'
 import { fontMetricsForFamily } from '../fonts'
 import {
@@ -642,6 +642,9 @@ export async function renderClip(job: RenderJob): Promise<RenderResult> {
   const loudness = source.hasAudio
     ? await measureLoudness(source.path, start, duration, job.signal)
     : null
+  if (process.env.CLIPFORGE_DEBUG) {
+    console.error(`[render] loudness normalisation: ${normalisationMode(loudness)}`, loudness)
+  }
 
   const tempDir = join(tmpdir(), 'clipforge')
   await mkdir(tempDir, { recursive: true })

--- a/src/main/pipeline/render.ts
+++ b/src/main/pipeline/render.ts
@@ -21,6 +21,7 @@ import { resolveCaptionStyle } from '@shared/captionStyles'
 import { computeZoomEvents, fitZoomEvents, remapZoomEvents, type ZoomEvent } from '@shared/zoom'
 import { planUploadEncode, type UploadEncodePlan } from '@shared/uploadBudget'
 import { FFMPEG_PATH, runFfmpegWith } from './ffmpeg'
+import { loudnormFilter, measureLoudness, type LoudnessStats } from './loudness'
 import { buildAss, fontsDir } from './captions'
 import { fontMetricsForFamily } from '../fonts'
 import {
@@ -30,9 +31,6 @@ import {
   resolveEncoder,
   sizeTargetedVideoArgs
 } from './encoders'
-
-/** Social platforms normalise to ~-14 LUFS; master exports to match. */
-const LOUDNORM = 'loudnorm=I=-14:TP=-1.5:LRA=11,aresample=48000'
 
 /**
  * Gentle audio fade at the clip tail so endings never cut off abruptly —
@@ -55,10 +53,16 @@ const FILTER_ARG_MAX_CHARS = 8000
  */
 const MAX_EXPRESSION_PIECES = 64
 
-function audioChain(clipDuration: number): string {
-  if (clipDuration <= END_FADE_SEC * 3) return LOUDNORM
+/**
+ * Loudness-normalised master chain: linear normalisation when the source was
+ * measured (see loudness.ts), the single-pass filter otherwise; loudnorm
+ * resamples internally, so the rate is pinned back to 48 kHz after it.
+ */
+function audioChain(clipDuration: number, loudness: LoudnessStats | null): string {
+  const master = `${loudnormFilter(loudness)},aresample=48000`
+  if (clipDuration <= END_FADE_SEC * 3) return master
   const st = (clipDuration - END_FADE_SEC).toFixed(3)
-  return `${LOUDNORM},afade=t=out:st=${st}:d=${END_FADE_SEC}`
+  return `${master},afade=t=out:st=${st}:d=${END_FADE_SEC}`
 }
 
 function targetDims(aspect: AspectRatio, source: VideoInfo): { w: number; h: number } {
@@ -400,6 +404,11 @@ export function buildFilterGraph(
      * long focus track is thinned into a plain expression instead.
      */
     focusCommandsPath?: string
+    /**
+     * Measured loudness of the source span, for linear normalisation. Null or
+     * absent falls back to single-pass dynamic normalisation.
+     */
+    loudness?: LoudnessStats | null
   }
 ): FilterGraph {
   const { w, h } = targetDims(clip.edit.aspect, source)
@@ -431,13 +440,13 @@ export function buildFilterGraph(
     parts.push(tightenGraph(tighten.segments, tighten.clipStart, source.hasAudio))
     parts.push(reframeGraph(clip, source, 'vcat', focus, focusCommandsPath))
     if (source.hasAudio) {
-      parts.push(`[acat]${audioChain(clipDuration)}[aout]`)
+      parts.push(`[acat]${audioChain(clipDuration, options?.loudness ?? null)}[aout]`)
       audioLabel = 'aout'
     }
   } else {
     parts.push(reframeGraph(clip, source, '0:v', focus, focusCommandsPath))
     if (source.hasAudio) {
-      parts.push(`[0:a]${audioChain(clipDuration)}[aout]`)
+      parts.push(`[0:a]${audioChain(clipDuration, options?.loudness ?? null)}[aout]`)
       audioLabel = 'aout'
     }
   }
@@ -626,6 +635,14 @@ export async function renderClip(job: RenderJob): Promise<RenderResult> {
     if (zoomEvents.length === 0) zoomEvents = null
   }
 
+  // Measure the span's loudness so the master gain is one linear value rather
+  // than a gain rider (see loudness.ts). Measured on the untightened span:
+  // integrated loudness gates out silence anyway, so removing pauses changes
+  // the reading by a fraction of a dB — not worth a second trim+concat graph.
+  const loudness = source.hasAudio
+    ? await measureLoudness(source.path, start, duration, job.signal)
+    : null
+
   const tempDir = join(tmpdir(), 'clipforge')
   await mkdir(tempDir, { recursive: true })
   // Named up front because the graph has to reference the file; it is only
@@ -637,7 +654,13 @@ export async function renderClip(job: RenderJob): Promise<RenderResult> {
     assPath,
     outputDuration,
     segments ? { segments, clipStart: start } : null,
-    { branding: job.branding, fontsDirPath: job.fontsDirPath, zoomEvents, focusCommandsPath }
+    {
+      branding: job.branding,
+      fontsDirPath: job.fontsDirPath,
+      zoomEvents,
+      focusCommandsPath,
+      loudness
+    }
   )
   if (graph.focusCommands) await writeFile(focusCommandsPath, graph.focusCommands, 'utf8')
 

--- a/src/main/pipeline/transcribe.ts
+++ b/src/main/pipeline/transcribe.ts
@@ -1,5 +1,5 @@
 import type { Transcript, TranscriptSegment, TranscriptWord } from '@shared/types'
-import { transcribeAudioFile, type WhisperResponse } from './openai'
+import { transcribeAudioFile, type WhisperResponse, type WhisperSegment } from './openai'
 import type { AudioChunk } from './ffmpeg'
 
 /**
@@ -16,9 +16,74 @@ export interface ChunkResult {
 }
 
 /**
+ * Whisper's own thresholds for treating a decoded segment as silence: it
+ * only trusts a high no-speech probability when the text it produced is also
+ * low-confidence. A segment failing both is what it emits over music, room
+ * tone and dead air — "Thank you for watching", a repeated phrase, a stray
+ * sentence in another language.
+ */
+export const NO_SPEECH_THRESHOLD = 0.6
+export const LOGPROB_THRESHOLD = -1.0
+/**
+ * gzip ratio of the segment text above which the decoder has looped. Real
+ * speech compresses to roughly 1.3–1.8; "you you you you you" goes far past
+ * this. Whisper itself uses the same cut-off to reject a decoding attempt.
+ */
+export const COMPRESSION_RATIO_THRESHOLD = 2.4
+
+/**
+ * Whether a Whisper segment is a decoder hallucination rather than speech.
+ * Segments without diagnostics are trusted. Pure and exported for tests.
+ */
+export function isHallucinatedSegment(seg: WhisperSegment): boolean {
+  if (seg.compression_ratio !== undefined && seg.compression_ratio > COMPRESSION_RATIO_THRESHOLD) {
+    return true
+  }
+  return (
+    seg.no_speech_prob !== undefined &&
+    seg.avg_logprob !== undefined &&
+    seg.no_speech_prob > NO_SPEECH_THRESHOLD &&
+    seg.avg_logprob < LOGPROB_THRESHOLD
+  )
+}
+
+/** Shortest a word may be on screen; shorter looks like a flicker. */
+export const MIN_WORD_SEC = 0.05
+/** Length given to a word Whisper reported with no duration at all. */
+const FILL_WORD_SEC = 0.15
+
+/**
+ * Make word timings usable for karaoke captions: sorted, non-overlapping and
+ * every word at least `MIN_WORD_SEC` long. Whisper word timestamps are noisy
+ * at the edges — a word can start before the previous one ends, or have zero
+ * (even negative) length — and the caption generators drop any word whose
+ * window is empty, so such a word would never light up. Mutates and returns
+ * the array. Pure and exported for tests.
+ */
+export function normalizeWordTimings(words: TranscriptWord[]): TranscriptWord[] {
+  words.sort((a, b) => a.start - b.start)
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i]
+    const prev = words[i - 1]
+    if (prev && word.start < prev.end) word.start = prev.end
+    const floor = word.start + MIN_WORD_SEC
+    if (word.end < floor) {
+      const next = words[i + 1]
+      const natural = word.start + FILL_WORD_SEC
+      // Grow into the gap before the next word when there is one; otherwise
+      // take the minimum and let the next word be nudged along on its turn.
+      word.end = next ? (next.start >= floor ? Math.min(natural, next.start) : floor) : natural
+    }
+  }
+  return words
+}
+
+/**
  * Merge per-chunk Whisper responses into one transcript with absolute
  * timestamps. Pure and exported for unit tests.
  *
+ * - Hallucinated segments (see isHallucinatedSegment) are dropped, along
+ *   with the words Whisper placed inside them.
  * - Words: kept from the chunk whose [keepFromSec, keepToSec) window contains
  *   their start — a disjoint tiling, so the merged word pool has no
  *   duplicates and no gaps.
@@ -42,9 +107,19 @@ export function stitchChunkResults(results: ChunkResult[]): Transcript {
     const inWindow = (absStart: number): boolean =>
       absStart >= chunk.keepFromSec && absStart < chunk.keepToSec
 
+    // Spans (chunk-local seconds) of segments judged to be hallucinations;
+    // words falling inside them go too.
+    const dropped: Array<[number, number]> = []
+    for (const seg of res.segments ?? []) {
+      if (isHallucinatedSegment(seg)) dropped.push([seg.start, seg.end])
+    }
+    const inDropped = (localMid: number): boolean =>
+      dropped.some(([from, to]) => localMid >= from && localMid <= to)
+
     for (const w of res.words ?? []) {
       const start = w.start + chunk.offsetSec
       if (!inWindow(start)) continue
+      if (dropped.length > 0 && inDropped((w.start + w.end) / 2)) continue
       const text = w.word.trim()
       if (text.length === 0) continue
       pool.push({ text, start, end: w.end + chunk.offsetSec })
@@ -53,6 +128,7 @@ export function stitchChunkResults(results: ChunkResult[]): Transcript {
     for (const seg of res.segments ?? []) {
       const start = seg.start + chunk.offsetSec
       if (!inWindow(start)) continue
+      if (isHallucinatedSegment(seg)) continue
       segments.push({
         id: 0, // renumbered after sorting
         text: seg.text.trim(),
@@ -63,7 +139,7 @@ export function stitchChunkResults(results: ChunkResult[]): Transcript {
     }
   }
 
-  pool.sort((a, b) => a.start - b.start)
+  normalizeWordTimings(pool)
   segments.sort((a, b) => a.start - b.start)
   segments.forEach((seg, i) => (seg.id = i))
 
@@ -83,6 +159,21 @@ export function stitchChunkResults(results: ChunkResult[]): Transcript {
   }
 
   return { language, durationSec: duration, segments }
+}
+
+/**
+ * Text of a chunk with hallucinated segments removed, for priming the next
+ * chunk. Feeding a hallucination back in as the prompt is the classic way
+ * Whisper is talked into repeating it for the rest of the file.
+ */
+export function trustedChunkText(res: WhisperResponse): string {
+  const segments = res.segments
+  if (!segments || segments.length === 0) return res.text ?? ''
+  return segments
+    .filter((seg) => !isHallucinatedSegment(seg))
+    .map((seg) => seg.text.trim())
+    .filter(Boolean)
+    .join(' ')
 }
 
 /**
@@ -109,7 +200,7 @@ export async function transcribeChunks(
       language,
       signal
     })
-    previousTail = (res.text ?? '').slice(-600)
+    previousTail = trustedChunkText(res).slice(-600)
     results.push({ chunk, res })
     onProgress?.((i + 1) / chunks.length)
   }

--- a/src/main/pipeline/wholeVideo.ts
+++ b/src/main/pipeline/wholeVideo.ts
@@ -125,6 +125,7 @@ export async function captionWholeVideo(
       hashtags: [],
       thumbnailPath,
       focusTrack,
+      reframeStatus: 'done',
       contentType,
       broll: [],
       edit: wholeVideoEdit({

--- a/src/main/projects.ts
+++ b/src/main/projects.ts
@@ -86,6 +86,8 @@ export async function loadProject(id: string): Promise<Project> {
     clip.origin ??= 'ai-highlight'
     clip.focusTrack ??= null
     clip.contentType ??= null
+    // Every clip saved before lazy reframing existed had its analysis run eagerly.
+    clip.reframeStatus ??= 'done'
     clip.edit.framing ??= 'manual'
     clip.edit.tightenCuts ??= false
     clip.edit.autoZoom ??= false

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,6 +40,8 @@ const api = {
     ipcRenderer.invoke('project:relinkVideo', projectId),
   updateClip: (projectId: string, clip: Clip): Promise<Project> =>
     ipcRenderer.invoke('project:updateClip', projectId, clip),
+  ensureReframe: (projectId: string, clipId: string): Promise<Project> =>
+    ipcRenderer.invoke('clip:ensureReframe', projectId, clipId),
   updateTranscriptWord: (
     projectId: string,
     segmentId: number,

--- a/src/renderer/src/components/EditorScreen.tsx
+++ b/src/renderer/src/components/EditorScreen.tsx
@@ -56,7 +56,7 @@ export default function EditorScreen(): React.JSX.Element {
   const customFonts = useStore((s) => s.customFonts)
   const brandColors = useStore((s) => s.settings?.branding.colors)
   const ensureReframe = useStore((s) => s.ensureReframe)
-  const reframeBusy = useStore((s) => s.reframeBusy)
+  const reframeError = useStore((s) => s.reframeError)
 
   const clip = project?.clips.find((c) => c.id === selectedClipId) ?? null
 
@@ -257,22 +257,36 @@ export default function EditorScreen(): React.JSX.Element {
                   full frame stays visible.
                 </p>
               )}
+              {reframePending && (
+                <p
+                  data-testid="reframe-pending"
+                  className="mt-2 flex items-center gap-1.5 text-[11px] leading-relaxed text-zinc-500"
+                >
+                  {reframeError[clip.id] ? (
+                    <>
+                      <ScanFace size={12} className="shrink-0" />
+                      <span>
+                        Speaker framing could not be analysed ({reframeError[clip.id]}).{' '}
+                        <button
+                          type="button"
+                          onClick={() => void ensureReframe(clip.id, true)}
+                          className="underline decoration-zinc-600 hover:text-zinc-300"
+                        >
+                          Retry
+                        </button>
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <Loader2 size={12} className="shrink-0 animate-spin" />
+                      Analysing speaker framing… the crop follows whoever is talking once this
+                      lands. Layout choices you make now are kept.
+                    </>
+                  )}
+                </p>
+              )}
               {clip.edit.reframeMode === 'crop' && (
                 <>
-                  {reframePending && (
-                    <p
-                      data-testid="reframe-pending"
-                      className="mt-2 flex items-center gap-1.5 text-[11px] leading-relaxed text-zinc-500"
-                    >
-                      {reframeBusy[clip.id] ? (
-                        <Loader2 size={12} className="shrink-0 animate-spin" />
-                      ) : (
-                        <ScanFace size={12} className="shrink-0" />
-                      )}
-                      Analysing speaker framing… the crop follows whoever is talking once this
-                      lands. You can keep editing meanwhile.
-                    </p>
-                  )}
                   {clip.focusTrack && (
                     <div className="mt-3 grid grid-cols-2 gap-1.5">
                       {(

--- a/src/renderer/src/components/EditorScreen.tsx
+++ b/src/renderer/src/components/EditorScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import type { TimelineData } from '@shared/types'
 import { isWholeVideoClip } from '@shared/wholeVideo'
+import { needsReframe } from '@shared/reframe'
 import { useStore } from '../store'
 import PreviewPlayer from './PreviewPlayer'
 import TrimBar from './TrimBar'
@@ -54,6 +55,8 @@ export default function EditorScreen(): React.JSX.Element {
   const exports = useStore((s) => s.exports)
   const customFonts = useStore((s) => s.customFonts)
   const brandColors = useStore((s) => s.settings?.branding.colors)
+  const ensureReframe = useStore((s) => s.ensureReframe)
+  const reframeBusy = useStore((s) => s.reframeBusy)
 
   const clip = project?.clips.find((c) => c.id === selectedClipId) ?? null
 
@@ -85,6 +88,14 @@ export default function EditorScreen(): React.JSX.Element {
     }
   }, [videoPath, sourceMissing, windowStart, windowEnd, timelineKey])
   const timeline = loadedTimeline?.key === timelineKey ? loadedTimeline.data : null
+
+  // Clips outside the pipeline's top tier arrive without speaker framing;
+  // opening one is what triggers the analysis (see shared/reframe.ts).
+  const clipId = clip?.id ?? null
+  const reframePending = clip ? needsReframe(clip) : false
+  useEffect(() => {
+    if (clipId && reframePending && !sourceMissing) void ensureReframe(clipId)
+  }, [clipId, reframePending, sourceMissing, ensureReframe])
 
   if (!project || !clip) return <div />
 
@@ -248,6 +259,20 @@ export default function EditorScreen(): React.JSX.Element {
               )}
               {clip.edit.reframeMode === 'crop' && (
                 <>
+                  {reframePending && (
+                    <p
+                      data-testid="reframe-pending"
+                      className="mt-2 flex items-center gap-1.5 text-[11px] leading-relaxed text-zinc-500"
+                    >
+                      {reframeBusy[clip.id] ? (
+                        <Loader2 size={12} className="shrink-0 animate-spin" />
+                      ) : (
+                        <ScanFace size={12} className="shrink-0" />
+                      )}
+                      Analysing speaker framing… the crop follows whoever is talking once this
+                      lands. You can keep editing meanwhile.
+                    </p>
+                  )}
                   {clip.focusTrack && (
                     <div className="mt-3 grid grid-cols-2 gap-1.5">
                       {(

--- a/src/renderer/src/components/PreviewPlayer.tsx
+++ b/src/renderer/src/components/PreviewPlayer.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Play, Pause, RotateCcw } from 'lucide-react'
 import type { Clip, Project, WatermarkPosition } from '@shared/types'
 import { hexToRgba, resolveCaptionStyle } from '@shared/captionStyles'
-import { groupWords, wordsInRange } from '@shared/captionLayout'
+import {
+  captionLayoutBudget,
+  groupDisplayEnd,
+  groupWords,
+  wordsInRange
+} from '@shared/captionLayout'
 import { computeKeptSegments, TimeMap } from '@shared/tighten'
 import { clipAllowsAutoZoom } from '@shared/contentType'
 import { computeZoomEvents, fitZoomEvents } from '@shared/zoom'
@@ -272,6 +277,7 @@ export default function PreviewPlayer({
             transcript={project.transcript}
             clip={clip}
             time={time}
+            aspectRatio={aspectStyle}
           />
         )}
         {clip.edit.showTitle && (clip.hook || clip.title) && time - start < Math.min(4, duration) && (
@@ -419,69 +425,84 @@ function BrollOverlay({ clip, time }: { clip: Clip; time: number }): React.JSX.E
 function CaptionOverlay({
   transcript,
   clip,
-  time
+  time,
+  aspectRatio
 }: {
   transcript: NonNullable<Project['transcript']>
   clip: Clip
   time: number
+  /** Output frame width / height; decides how much text fits on a line. */
+  aspectRatio: number
 }): React.JSX.Element | null {
   const brandColors = useStore((s) => s.settings?.branding.colors)
-  const style = resolveCaptionStyle(
-    clip.edit.captionStyleId,
-    brandColors,
-    clip.edit.captionFontFamily
+  const style = useMemo(
+    () => resolveCaptionStyle(clip.edit.captionStyleId, brandColors, clip.edit.captionFontFamily),
+    [clip.edit.captionStyleId, brandColors, clip.edit.captionFontFamily]
   )
 
+  // Same grouping and line layout the ASS export uses, so what wraps here
+  // wraps identically in the file.
   const groups = useMemo(() => {
     const words = wordsInRange(transcript, clip.edit.start, clip.edit.end)
-    return groupWords(words, style.wordsPerGroup)
-  }, [transcript, clip.edit.start, clip.edit.end, style.wordsPerGroup])
+    return groupWords(words, captionLayoutBudget(style, aspectRatio))
+  }, [transcript, clip.edit.start, clip.edit.end, style, aspectRatio])
 
-  const group = groups.find((g) => time >= g.start && time <= g.end + 0.05)
-  if (!group) return null
+  const groupIndex = groups.findIndex(
+    (g, i) => time >= g.start && time < groupDisplayEnd(groups, i, clip.edit.end)
+  )
+  if (groupIndex === -1) return null
+  const group = groups[groupIndex]
 
   let activeIdx = -1
   for (let i = 0; i < group.words.length; i++) {
     if (time >= group.words[i].start) activeIdx = i
   }
 
+  let index = 0
   return (
     <div
-      className="pointer-events-none absolute inset-x-0 flex justify-center px-[5cqw] text-center"
+      className="pointer-events-none absolute inset-x-0 flex flex-col items-center text-center"
       style={{ top: `${style.positionY * 100}cqh`, transform: 'translateY(-50%)' }}
     >
-      <div
-        style={{
-          fontFamily: `'${style.fontFamily}', sans-serif`,
-          fontSize: `${style.fontScale * 100}cqh`,
-          fontWeight: style.bold ? 700 : 400,
-          lineHeight: 1.25,
-          textShadow:
-            style.outlineWidth > 0
-              ? `0 0 ${style.outlineWidth * 2}px ${style.outlineColor}, 2px 2px ${style.outlineWidth}px ${style.outlineColor}, -2px 2px ${style.outlineWidth}px ${style.outlineColor}, 2px -2px ${style.outlineWidth}px ${style.outlineColor}, -2px -2px ${style.outlineWidth}px ${style.outlineColor}`
-              : 'none'
-        }}
-      >
-        {group.words.map((w, i) => {
-          const active = i === activeIdx
-          const text = style.uppercase ? w.text.toUpperCase() : w.text
-          return (
-            <span
-              key={`${w.start}-${i}`}
-              className={active ? 'caption-pop inline-block' : 'inline-block'}
-              style={{
-                color: active ? style.highlightColor : style.textColor,
-                backgroundColor: active && style.highlightBoxColor ? style.highlightBoxColor : 'transparent',
-                borderRadius: style.highlightBoxColor ? '0.35em' : undefined,
-                padding: style.highlightBoxColor ? '0 0.18em' : undefined,
-                marginRight: '0.28em'
-              }}
-            >
-              {text}
-            </span>
-          )
-        })}
-      </div>
+      {group.lines.map((line, li) => (
+        <div
+          key={li}
+          className="whitespace-nowrap"
+          style={{
+            fontFamily: `'${style.fontFamily}', sans-serif`,
+            fontSize: `${style.fontScale * 100}cqh`,
+            fontWeight: style.bold ? 700 : 400,
+            lineHeight: 1.25,
+            textShadow:
+              style.outlineWidth > 0
+                ? `0 0 ${style.outlineWidth * 2}px ${style.outlineColor}, 2px 2px ${style.outlineWidth}px ${style.outlineColor}, -2px 2px ${style.outlineWidth}px ${style.outlineColor}, 2px -2px ${style.outlineWidth}px ${style.outlineColor}, -2px -2px ${style.outlineWidth}px ${style.outlineColor}`
+                : 'none'
+          }}
+        >
+          {line.map((w, wi) => {
+            const wordIndex = index++
+            const active = wordIndex === activeIdx
+            const text = style.uppercase ? w.text.toUpperCase() : w.text
+            return (
+              <span
+                key={`${w.start}-${wordIndex}`}
+                className={active ? 'caption-pop inline-block' : 'inline-block'}
+                style={{
+                  color: active ? style.highlightColor : style.textColor,
+                  backgroundColor:
+                    active && style.highlightBoxColor ? style.highlightBoxColor : 'transparent',
+                  borderRadius: style.highlightBoxColor ? '0.35em' : undefined,
+                  padding: style.highlightBoxColor ? '0 0.18em' : undefined,
+                  // Word gap mirrors the ASS space; none after the line's last word.
+                  marginRight: wi === line.length - 1 ? undefined : '0.28em'
+                }}
+              >
+                {text}
+              </span>
+            )
+          })}
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/renderer/src/components/ProcessingScreen.tsx
+++ b/src/renderer/src/components/ProcessingScreen.tsx
@@ -13,7 +13,7 @@ const CLIP_STAGES: StageRow[] = [
   { id: 'audio', label: 'Extract audio', icon: FileAudio },
   { id: 'transcribe', label: 'Transcribe speech', icon: AudioLines },
   { id: 'analyze', label: 'Find viral moments', icon: Brain },
-  { id: 'reframe', label: 'Detect layout (faces vs screen share)', icon: ScanFace },
+  { id: 'reframe', label: 'Detect layout for the top clips (faces vs screen share)', icon: ScanFace },
   { id: 'broll', label: 'Find B-roll images', icon: ImagePlus },
   { id: 'thumbnails', label: 'Create thumbnails', icon: Image }
 ]

--- a/src/renderer/src/components/SizeTargetControls.tsx
+++ b/src/renderer/src/components/SizeTargetControls.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { HardDrive } from 'lucide-react'
 import { useStore } from '../store'
 import {
@@ -29,54 +30,25 @@ export default function SizeTargetControls({
   }
   const setMb = (value: number): void => {
     const next = normalizeSizeTargetMb(value)
-    if (next === null) return
+    if (next === null || next === mb) return
     void saveSettings({ sizeTargetMb: next })
   }
 
   if (compact) {
     return (
       <div data-testid="export-size-limit" className="mb-3">
-        <button
-          type="button"
-          onClick={() => setEnabled(!enabled)}
-          className="flex w-full items-center justify-between gap-3 rounded-lg border border-surface-600 px-3 py-2.5 text-left text-xs font-medium text-zinc-300 transition hover:bg-surface-800"
-        >
-          Fit under a size limit
-          <span
-            className={`relative h-5 w-9 shrink-0 rounded-full transition ${enabled ? 'bg-zinc-100' : 'bg-surface-600'}`}
-          >
-            <span
-              className={`absolute top-0.5 h-4 w-4 rounded-full transition-all ${enabled ? 'left-[18px] bg-zinc-900' : 'left-0.5 bg-white'}`}
-            />
-          </span>
-        </button>
+        <SizeToggle label="Fit under a size limit" enabled={enabled} onToggle={() => setEnabled(!enabled)} className="" />
         {enabled && (
           <div className="mt-2 flex items-center gap-2">
-            <input
-              type="number"
-              min={MIN_SIZE_TARGET_MB}
-              max={MAX_SIZE_TARGET_MB}
-              step={1}
-              value={mb}
-              onChange={(e) => setMb(Number(e.target.value))}
+            <SizeInput
+              key={mb}
+              mb={mb}
+              onCommit={setMb}
               className="w-20 rounded-lg border border-surface-600 bg-surface-850 px-2.5 py-1.5 text-xs tabular-nums text-zinc-200 focus:border-white/25 focus:outline-none"
             />
             <span className="text-[11px] text-zinc-500">MB</span>
             <div className="flex flex-1 flex-wrap gap-1">
-              {SIZE_PRESETS_MB.map((preset) => (
-                <button
-                  key={preset}
-                  type="button"
-                  onClick={() => setMb(preset)}
-                  className={`rounded-md border px-1.5 py-0.5 text-[10px] font-medium transition ${
-                    mb === preset
-                      ? 'border-white/30 bg-white/[0.07] text-zinc-200'
-                      : 'border-surface-600 text-zinc-500 hover:bg-surface-800'
-                  }`}
-                >
-                  {preset}
-                </button>
-              ))}
+              <SizePresets mb={mb} onPick={setMb} compact />
             </div>
           </div>
         )}
@@ -95,52 +67,133 @@ export default function SizeTargetControls({
         rejects large files. Quality and GPU encoder are ignored while this is on: the cap
         decides the bitrate, on CPU.
       </p>
-      <button
-        type="button"
-        onClick={() => setEnabled(!enabled)}
-        className="mt-2.5 flex w-full items-center justify-between gap-3 rounded-lg border border-surface-600 px-3 py-2.5 text-left text-xs font-medium text-zinc-300 transition hover:bg-surface-800"
-      >
-        Limit export size
-        <span
-          className={`relative h-5 w-9 shrink-0 rounded-full transition ${enabled ? 'bg-zinc-100' : 'bg-surface-600'}`}
-        >
-          <span
-            className={`absolute top-0.5 h-4 w-4 rounded-full transition-all ${enabled ? 'left-[18px] bg-zinc-900' : 'left-0.5 bg-white'}`}
-          />
-        </span>
-      </button>
+      <SizeToggle label="Limit export size" enabled={enabled} onToggle={() => setEnabled(!enabled)} className="mt-2.5" />
       {enabled && (
         <>
           <div className="mt-2.5 flex items-center gap-2">
-            <input
-              type="number"
-              min={MIN_SIZE_TARGET_MB}
-              max={MAX_SIZE_TARGET_MB}
-              step={1}
-              value={mb}
-              onChange={(e) => setMb(Number(e.target.value))}
+            <SizeInput
+              key={mb}
+              mb={mb}
+              onCommit={setMb}
               className="w-24 rounded-xl border border-surface-600 bg-surface-850 px-3 py-2 text-sm tabular-nums text-zinc-200 focus:border-white/25 focus:outline-none"
             />
             <span className="text-xs text-zinc-500">MB</span>
           </div>
           <div className="mt-2 grid grid-cols-5 gap-1.5">
-            {SIZE_PRESETS_MB.map((preset) => (
-              <button
-                key={preset}
-                type="button"
-                onClick={() => setMb(preset)}
-                className={`rounded-lg border px-2 py-1.5 text-center text-[11px] font-medium transition ${
-                  mb === preset
-                    ? 'border-white/30 bg-white/[0.07] text-zinc-100'
-                    : 'border-surface-600 text-zinc-400 hover:bg-surface-800'
-                }`}
-              >
-                {preset} MB
-              </button>
-            ))}
+            <SizePresets mb={mb} onPick={setMb} />
           </div>
         </>
       )}
     </div>
+  )
+}
+
+function SizeToggle({
+  label,
+  enabled,
+  onToggle,
+  className
+}: {
+  label: string
+  enabled: boolean
+  onToggle: () => void
+  className: string
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={`${className} flex w-full items-center justify-between gap-3 rounded-lg border border-surface-600 px-3 py-2.5 text-left text-xs font-medium text-zinc-300 transition hover:bg-surface-800`}
+    >
+      {label}
+      <span
+        className={`relative h-5 w-9 shrink-0 rounded-full transition ${enabled ? 'bg-zinc-100' : 'bg-surface-600'}`}
+      >
+        <span
+          className={`absolute top-0.5 h-4 w-4 rounded-full transition-all ${enabled ? 'left-[18px] bg-zinc-900' : 'left-0.5 bg-white'}`}
+        />
+      </span>
+    </button>
+  )
+}
+
+/**
+ * The megabyte field edits a local draft and commits on blur or Enter. Bound
+ * straight to the saved setting it could never be cleared (an empty field
+ * normalises to null, which is "off", so the value snapped back on every
+ * Backspace) and each accepted keystroke rewrote the settings file.
+ */
+function SizeInput({
+  mb,
+  onCommit,
+  className
+}: {
+  mb: number
+  onCommit: (value: number) => void
+  className: string
+}): React.JSX.Element {
+  // Remounted by the caller (key={mb}) whenever the saved value changes, so
+  // the draft starts from the saved value without an effect syncing it.
+  const [draft, setDraft] = useState(String(mb))
+  const commit = (): void => {
+    const next = normalizeSizeTargetMb(draft)
+    if (next === null) {
+      setDraft(String(mb))
+      return
+    }
+    setDraft(String(next))
+    onCommit(next)
+  }
+  return (
+    <input
+      type="number"
+      min={MIN_SIZE_TARGET_MB}
+      max={MAX_SIZE_TARGET_MB}
+      step={1}
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+      }}
+      className={className}
+    />
+  )
+}
+
+function SizePresets({
+  mb,
+  onPick,
+  compact = false
+}: {
+  mb: number
+  onPick: (value: number) => void
+  compact?: boolean
+}): React.JSX.Element {
+  return (
+    <>
+      {SIZE_PRESETS_MB.map((preset) => (
+        <button
+          key={preset}
+          type="button"
+          onClick={() => onPick(preset)}
+          className={
+            compact
+              ? `rounded-md border px-1.5 py-0.5 text-[10px] font-medium transition ${
+                  mb === preset
+                    ? 'border-white/30 bg-white/[0.07] text-zinc-200'
+                    : 'border-surface-600 text-zinc-500 hover:bg-surface-800'
+                }`
+              : `rounded-lg border px-2 py-1.5 text-center text-[11px] font-medium transition ${
+                  mb === preset
+                    ? 'border-white/30 bg-white/[0.07] text-zinc-100'
+                    : 'border-surface-600 text-zinc-400 hover:bg-surface-800'
+                }`
+          }
+        >
+          {compact ? preset : `${preset} MB`}
+        </button>
+      ))}
+    </>
   )
 }

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -116,9 +116,14 @@ interface AppState {
   updateClipLocal: (clip: Clip) => void
   generateCaption: (clipId: string) => Promise<void>
   captionBusy: Record<string, boolean>
-  /** Run the deferred reframe analysis for a clip the pipeline left pending. */
-  ensureReframe: (clipId: string) => Promise<void>
+  /**
+   * Run the deferred reframe analysis for a clip the pipeline left pending.
+   * A clip whose last attempt failed is skipped until `retry` is passed, so
+   * a broken clip does not loop; the editor offers the retry.
+   */
+  ensureReframe: (clipId: string, retry?: boolean) => Promise<void>
   reframeBusy: Record<string, boolean>
+  reframeError: Record<string, string>
   updateTranscriptWord: (segmentId: number, wordIndex: number, text: string) => Promise<void>
   exportClip: (clipId: string) => Promise<void>
   cancelExport: (clipId: string) => Promise<void>
@@ -157,6 +162,7 @@ export const useStore = create<AppState>((set, get) => ({
   sourceUpdate: { status: 'idle', message: '' },
   captionBusy: {},
   reframeBusy: {},
+  reframeError: {},
 
   init: async () => {
     const [settings, projects, customFonts] = await Promise.all([
@@ -378,12 +384,15 @@ export const useStore = create<AppState>((set, get) => ({
     }
   },
 
-  ensureReframe: async (clipId) => {
+  ensureReframe: async (clipId, retry = false) => {
     const project = get().project
     if (!project || get().reframeBusy[clipId]) return
+    if (get().reframeError[clipId] && !retry) return
     const clip = project.clips.find((c) => c.id === clipId)
     if (!clip || !needsReframe(clip)) return
-    set({ reframeBusy: { ...get().reframeBusy, [clipId]: true } })
+    const errors = { ...get().reframeError }
+    delete errors[clipId]
+    set({ reframeBusy: { ...get().reframeBusy, [clipId]: true }, reframeError: errors })
     try {
       const updated = await window.clipforge.ensureReframe(project.id, clipId)
       const fresh = updated.clips.find((c) => c.id === clipId)
@@ -393,14 +402,17 @@ export const useStore = create<AppState>((set, get) => ({
         set({
           project: {
             ...current,
-            clips: current.clips.map((c) => (c.id === clipId ? mergeReframeResult(c, fresh) : c))
+            clips: current.clips.map((c) =>
+              c.id === clipId ? mergeReframeResult(c, fresh, updated.videoType) : c
+            )
           }
         })
       }
     } catch (err) {
-      // The clip stays pending and is retried next time it is opened; the
-      // editor works meanwhile on the default centre crop.
-      console.error('Reframe analysis failed:', err)
+      // The clip stays pending; the editor shows the failure with a retry and
+      // works meanwhile on the default centre crop.
+      const message = err instanceof Error ? cleanIpcError(err.message) : String(err)
+      set({ reframeError: { ...get().reframeError, [clipId]: message } })
     } finally {
       const busy = { ...get().reframeBusy }
       delete busy[clipId]

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -15,6 +15,7 @@ import type {
 } from '@shared/types'
 
 import { findWholeVideoClip, highlightClips, isWholeVideoClip } from '@shared/wholeVideo'
+import { mergeReframeResult, needsReframe } from '@shared/reframe'
 
 /** Font faces already registered with document.fonts (FontFace API). */
 const loadedFontFaces = new Map<string, FontFace>()
@@ -115,6 +116,9 @@ interface AppState {
   updateClipLocal: (clip: Clip) => void
   generateCaption: (clipId: string) => Promise<void>
   captionBusy: Record<string, boolean>
+  /** Run the deferred reframe analysis for a clip the pipeline left pending. */
+  ensureReframe: (clipId: string) => Promise<void>
+  reframeBusy: Record<string, boolean>
   updateTranscriptWord: (segmentId: number, wordIndex: number, text: string) => Promise<void>
   exportClip: (clipId: string) => Promise<void>
   cancelExport: (clipId: string) => Promise<void>
@@ -152,6 +156,7 @@ export const useStore = create<AppState>((set, get) => ({
   updateDownload: { status: 'idle', progress: 0 },
   sourceUpdate: { status: 'idle', message: '' },
   captionBusy: {},
+  reframeBusy: {},
 
   init: async () => {
     const [settings, projects, customFonts] = await Promise.all([
@@ -370,6 +375,36 @@ export const useStore = create<AppState>((set, get) => ({
       const busy = { ...get().captionBusy }
       delete busy[clipId]
       set({ captionBusy: busy })
+    }
+  },
+
+  ensureReframe: async (clipId) => {
+    const project = get().project
+    if (!project || get().reframeBusy[clipId]) return
+    const clip = project.clips.find((c) => c.id === clipId)
+    if (!clip || !needsReframe(clip)) return
+    set({ reframeBusy: { ...get().reframeBusy, [clipId]: true } })
+    try {
+      const updated = await window.clipforge.ensureReframe(project.id, clipId)
+      const fresh = updated.clips.find((c) => c.id === clipId)
+      const current = get().project
+      // Graft only what the analysis owns: edits made while it ran stay.
+      if (fresh && current?.id === updated.id) {
+        set({
+          project: {
+            ...current,
+            clips: current.clips.map((c) => (c.id === clipId ? mergeReframeResult(c, fresh) : c))
+          }
+        })
+      }
+    } catch (err) {
+      // The clip stays pending and is retried next time it is opened; the
+      // editor works meanwhile on the default centre crop.
+      console.error('Reframe analysis failed:', err)
+    } finally {
+      const busy = { ...get().reframeBusy }
+      delete busy[clipId]
+      set({ reframeBusy: busy })
     }
   },
 

--- a/src/shared/captionLayout.ts
+++ b/src/shared/captionLayout.ts
@@ -1,12 +1,21 @@
 import type { Transcript, TranscriptWord } from './types'
+import type { CaptionStyle } from './captionStyles'
 
 /**
  * Word selection and grouping shared by the ASS generator (main process) and
  * the live caption preview (renderer), so preview and export stay in sync.
+ *
+ * Groups are laid out into explicit lines here, once, from a character budget
+ * derived from the style's font and the output frame. Both renderers then
+ * draw exactly those lines (the ASS uses hard `\N` breaks with wrapping off,
+ * the preview uses one non-wrapping block per line), so a caption can never
+ * wrap differently on export than it did in the editor.
  */
 
 export interface WordGroup {
   words: TranscriptWord[]
+  /** `words` split into the display lines they are drawn on, in order. */
+  lines: TranscriptWord[][]
   start: number
   end: number
 }
@@ -31,30 +40,149 @@ export function wordsInRange(
 
 const MAX_PAUSE_IN_GROUP_SEC = 0.9
 
-export function groupWords(words: TranscriptWord[], wordsPerGroup: number): WordGroup[] {
-  const groups: WordGroup[] = []
-  let current: TranscriptWord[] = []
-  const flush = (): void => {
-    if (current.length === 0) return
-    groups.push({
-      words: current,
-      start: current[0].start,
-      end: current[current.length - 1].end
-    })
-    current = []
+/** Most lines a caption group may occupy. Three-line captions cover the face. */
+export const CAPTION_MAX_LINES = 2
+
+/**
+ * Share of the frame width caption text may span. The rest is a safe margin
+ * so text never kisses the edge on either renderer.
+ */
+export const CAPTION_SAFE_WIDTH = 0.9
+
+/**
+ * Frequency-weighted average glyph advance, in em, for the bundled caption
+ * fonts (measured from their hmtx tables over English letter frequencies).
+ * Uppercase runs wider in most faces, so styles that shout get their own
+ * figure. Unknown families (user uploads) use a deliberately wide default so a
+ * line is more likely to come up short than to overflow.
+ */
+const GLYPH_WIDTH_EM: Record<string, { lower: number; upper: number }> = {
+  Anton: { lower: 0.45, upper: 0.46 },
+  Poppins: { lower: 0.58, upper: 0.65 },
+  'Poppins Medium': { lower: 0.56, upper: 0.63 }
+}
+const DEFAULT_GLYPH_WIDTH_EM = { lower: 0.62, upper: 0.7 }
+/** A space is narrower than a letter in every face we ship. */
+const SPACE_WIDTH_EM = 0.26
+/**
+ * The active word pops to 109% for a beat. Only one word grows at a time, so a
+ * fixed allowance (about a long word's worth of growth) keeps the pop inside
+ * the safe width without throwing away a whole line's share.
+ */
+const POP_ALLOWANCE_EM = 0.5
+
+export interface CaptionLayoutBudget {
+  /** Most words in one group (the style's rhythm knob). */
+  maxWords: number
+  /** Width available for one line of text, in em of the caption font. */
+  lineWidthEm: number
+  /** Average glyph advance in em for this style's font and case. */
+  glyphWidthEm: number
+  maxLines: number
+}
+
+/**
+ * How much text fits on one caption line for a style on a frame of the given
+ * aspect ratio (width / height). Font size is a fraction of frame height, so
+ * the usable width in em is `aspect * safeWidth / fontScale`: a 9:16 frame
+ * fits far fewer characters than a 16:9 one at the same style.
+ */
+export function captionLayoutBudget(style: CaptionStyle, aspectRatio: number): CaptionLayoutBudget {
+  const widths = GLYPH_WIDTH_EM[style.fontFamily] ?? DEFAULT_GLYPH_WIDTH_EM
+  const safeAspect = Math.max(0.1, aspectRatio)
+  return {
+    maxWords: style.wordsPerGroup,
+    lineWidthEm: (safeAspect * CAPTION_SAFE_WIDTH) / style.fontScale - POP_ALLOWANCE_EM,
+    glyphWidthEm: style.uppercase ? widths.upper : widths.lower,
+    maxLines: CAPTION_MAX_LINES
   }
+}
+
+/** Estimated rendered width of a word, in em. */
+function wordWidthEm(text: string, glyphWidthEm: number): number {
+  return text.length * glyphWidthEm
+}
+
+/**
+ * Group words into caption cards and lay each card out into lines.
+ *
+ * A group breaks on the style's word cap, on a long pause, after a sentence
+ * end, or when the next word would need a third line. Within a group, words
+ * fill the current line until the next word would overflow the em budget,
+ * then start a new line. A single word wider than a whole line still gets a
+ * line to itself — it cannot be split, and overflowing one line beats
+ * dropping the word.
+ */
+export function groupWords(words: TranscriptWord[], budget: CaptionLayoutBudget): WordGroup[] {
+  const groups: WordGroup[] = []
+  const maxLines = Math.max(1, budget.maxLines)
+  const spaceEm = SPACE_WIDTH_EM
+  let lines: TranscriptWord[][] = []
+  let lineWidth = 0
+  let count = 0
+
+  const flush = (): void => {
+    if (count === 0) return
+    const flat = lines.flat()
+    groups.push({
+      words: flat,
+      lines,
+      start: flat[0].start,
+      end: flat[flat.length - 1].end
+    })
+    lines = []
+    lineWidth = 0
+    count = 0
+  }
+
   for (const w of words) {
-    const prev = current[current.length - 1]
-    const endsSentence = prev ? /[.!?]$/.test(prev.text) : false
+    const prev = count > 0 ? lines[lines.length - 1][lines[lines.length - 1].length - 1] : undefined
+    const endsSentence = prev ? /[.!?]["']?$/.test(prev.text) : false
+    const width = wordWidthEm(w.text, budget.glyphWidthEm)
+    const fitsCurrentLine = count === 0 || lineWidth + spaceEm + width <= budget.lineWidthEm
+    const needsNewLine = !fitsCurrentLine
+    const canStartLine = lines.length < maxLines
+
     if (
-      current.length >= wordsPerGroup ||
+      count >= budget.maxWords ||
       (prev && w.start - prev.end > MAX_PAUSE_IN_GROUP_SEC) ||
-      endsSentence
+      endsSentence ||
+      (needsNewLine && !canStartLine)
     ) {
       flush()
     }
-    current.push(w)
+
+    if (count === 0) {
+      lines.push([w])
+      lineWidth = width
+    } else if (lineWidth + spaceEm + width <= budget.lineWidthEm) {
+      lines[lines.length - 1].push(w)
+      lineWidth += spaceEm + width
+    } else {
+      lines.push([w])
+      lineWidth = width
+    }
+    count++
   }
   flush()
   return groups
+}
+
+/**
+ * How long a finished group stays on screen after its last word. Captions
+ * that vanish the instant a sentence ends leave an empty frame on every
+ * pause; holding briefly reads as natural, but never into the next group.
+ */
+export const CAPTION_HOLD_SEC = 1.5
+
+/**
+ * The moment group `index` leaves the screen: its last word's end plus the
+ * hold, cut short by the next group's first word or the clip end.
+ */
+export function groupDisplayEnd(groups: WordGroup[], index: number, clipEnd: number): number {
+  const group = groups[index]
+  const next = groups[index + 1]
+  let end = group.end + CAPTION_HOLD_SEC
+  if (next) end = Math.min(end, Math.max(group.end, next.start))
+  return Math.min(clipEnd, Math.max(group.end, end))
 }

--- a/src/shared/clipMetrics.ts
+++ b/src/shared/clipMetrics.ts
@@ -1,0 +1,112 @@
+import type { Transcript } from './types'
+import { wordsInRange } from './captionLayout'
+import { transcriptSentences, type Sentence } from './sentences'
+
+/**
+ * Boundary quality of a clip, measured against the transcript. The project
+ * lives or dies by where its clips start and stop, and these are the things
+ * a viewer notices in the first and last second: opening mid-thought,
+ * cutting a sentence off, or trailing into dead air. Pure functions shared by
+ * the eval script and the unit tests.
+ */
+
+export interface ClipBoundaryReport {
+  durationSec: number
+  wordCount: number
+  /** Seconds of room before the first word; null when the clip has no words. */
+  leadInSec: number | null
+  /** Seconds of room after the last word; null when the clip has no words. */
+  tailSec: number | null
+  /** The first word is not the first word of its sentence. */
+  startsMidSentence: boolean | null
+  /** The last word is not the last word of its sentence. */
+  endsMidSentence: boolean | null
+  openingSentence: string | null
+  closingSentence: string | null
+}
+
+/**
+ * Tail room the export needs: its 0.4 s audio fade sits after the last word,
+ * so anything shorter ducks speech. Beyond the upper bound the clip trails
+ * into dead air the viewer has to sit through.
+ */
+export const TAIL_MIN_SEC = 0.4
+export const TAIL_MAX_SEC = 1.5
+
+function sentenceOfWord(sentences: Sentence[], start: number): Sentence | null {
+  for (const s of sentences) {
+    if (start < s.start - 1e-6) return null
+    if (start <= s.end + 1e-6) return s
+  }
+  return null
+}
+
+export function analyzeClipBoundaries(
+  transcript: Transcript,
+  start: number,
+  end: number,
+  sentences: Sentence[] = transcriptSentences(transcript)
+): ClipBoundaryReport {
+  const words = wordsInRange(transcript, start, end)
+  const durationSec = end - start
+  if (words.length === 0) {
+    return {
+      durationSec,
+      wordCount: 0,
+      leadInSec: null,
+      tailSec: null,
+      startsMidSentence: null,
+      endsMidSentence: null,
+      openingSentence: null,
+      closingSentence: null
+    }
+  }
+  const first = words[0]
+  const last = words[words.length - 1]
+  const opening = sentenceOfWord(sentences, first.start)
+  const closing = sentenceOfWord(sentences, last.start)
+  return {
+    durationSec,
+    wordCount: words.length,
+    leadInSec: first.start - start,
+    tailSec: end - last.end,
+    startsMidSentence: opening ? opening.words[0] !== first : null,
+    endsMidSentence: closing ? closing.words[closing.words.length - 1] !== last : null,
+    openingSentence: opening?.text ?? null,
+    closingSentence: closing?.text ?? null
+  }
+}
+
+export interface BoundarySummary {
+  clips: number
+  /** Clips whose first word is not a sentence start. */
+  midSentenceStarts: number
+  /** Clips whose last word is not a sentence end. */
+  midSentenceEnds: number
+  /** Clips with too little tail for the audio fade. */
+  clippedTails: number
+  /** Clips trailing into dead air. */
+  deadAirTails: number
+  meanDurationSec: number
+  medianDurationSec: number
+  minDurationSec: number
+  maxDurationSec: number
+}
+
+export function summarizeBoundaries(reports: ClipBoundaryReport[]): BoundarySummary {
+  const durations = reports.map((r) => r.durationSec).sort((a, b) => a - b)
+  const n = reports.length
+  const median =
+    n === 0 ? 0 : n % 2 === 1 ? durations[(n - 1) / 2] : (durations[n / 2 - 1] + durations[n / 2]) / 2
+  return {
+    clips: n,
+    midSentenceStarts: reports.filter((r) => r.startsMidSentence === true).length,
+    midSentenceEnds: reports.filter((r) => r.endsMidSentence === true).length,
+    clippedTails: reports.filter((r) => r.tailSec !== null && r.tailSec < TAIL_MIN_SEC).length,
+    deadAirTails: reports.filter((r) => r.tailSec !== null && r.tailSec > TAIL_MAX_SEC).length,
+    meanDurationSec: n === 0 ? 0 : durations.reduce((a, b) => a + b, 0) / n,
+    medianDurationSec: median,
+    minDurationSec: n === 0 ? 0 : durations[0],
+    maxDurationSec: n === 0 ? 0 : durations[n - 1]
+  }
+}

--- a/src/shared/reframe.ts
+++ b/src/shared/reframe.ts
@@ -1,0 +1,69 @@
+import type { Clip } from './types'
+
+/**
+ * Which clips get their reframe analysis during the pipeline, and how a
+ * finished analysis is grafted onto a clip that may have been edited since.
+ *
+ * Reframe analysis (UltraFace + LR-ASD at 25 fps) is by far the slowest
+ * per-clip stage: tens of seconds of CPU per clip, against a few seconds for
+ * everything else. Running it for every candidate made an hour of source
+ * video take most of an hour to come back, most of it spent on clips the
+ * user would never open. So the pipeline analyses only the top tier and the
+ * rest are analysed on demand — when the clip is opened in the editor or
+ * exported (see main/pipeline/reframe.ts).
+ */
+
+/** Clips always analysed up front, however they score. */
+export const EAGER_REFRAME_MIN = 8
+/** Beyond the minimum, clips scoring at least this are also analysed up front… */
+export const EAGER_REFRAME_SCORE = 80
+/** …up to this many in total. */
+export const EAGER_REFRAME_MAX = 12
+
+/**
+ * Ids of the clips the pipeline should analyse eagerly. Input is the ranked
+ * list (highest score first); ties are resolved by rank. Pure and exported
+ * for tests.
+ */
+export function selectEagerReframeIds(ranked: Clip[]): Set<string> {
+  const eager = new Set<string>()
+  for (const clip of ranked) {
+    if (eager.size >= EAGER_REFRAME_MAX) break
+    if (eager.size < EAGER_REFRAME_MIN || clip.viralityScore >= EAGER_REFRAME_SCORE) {
+      eager.add(clip.id)
+    }
+  }
+  return eager
+}
+
+/** Whether a clip still needs its reframe analysis before it is fully framed. */
+export function needsReframe(clip: Clip): boolean {
+  return clip.reframeStatus === 'pending'
+}
+
+/**
+ * Graft the result of a reframe analysis onto the current copy of a clip.
+ *
+ * The analysis owns the focus track, the content classification and the
+ * layout defaults it derives from them (crop vs letterbox, auto vs manual
+ * framing, the starting focus and whether auto zoom makes sense). Everything
+ * else — title, trim, caption style, B-roll, the social caption — belongs to
+ * whoever has been editing the clip in the meantime and is kept from
+ * `current`. Used on both sides of the IPC boundary so the renderer's local
+ * state and the saved project converge on the same clip.
+ */
+export function mergeReframeResult(current: Clip, analysed: Clip): Clip {
+  return {
+    ...current,
+    focusTrack: analysed.focusTrack,
+    contentType: analysed.contentType,
+    reframeStatus: 'done',
+    edit: {
+      ...current.edit,
+      reframeMode: analysed.edit.reframeMode,
+      framing: analysed.edit.framing,
+      focusX: analysed.edit.focusX,
+      autoZoom: analysed.edit.autoZoom
+    }
+  }
+}

--- a/src/shared/reframe.ts
+++ b/src/shared/reframe.ts
@@ -1,4 +1,5 @@
-import type { Clip } from './types'
+import type { Clip, ClipEditState, VideoType } from './types'
+import { initialClipEditForVideoType } from './videoType'
 
 /**
  * Which clips get their reframe analysis during the pipeline, and how a
@@ -41,23 +42,43 @@ export function needsReframe(clip: Clip): boolean {
   return clip.reframeStatus === 'pending'
 }
 
+/** The layout fields the reframe analysis sets defaults for. */
+const LAYOUT_FIELDS = ['reframeMode', 'framing', 'focusX', 'autoZoom'] as const
+
+/**
+ * Whether a pending clip's layout is still the default it was created with
+ * for this video type — i.e. the user has not chosen a layout of their own
+ * while the analysis was outstanding.
+ */
+export function layoutUntouched(edit: ClipEditState, videoType: VideoType): boolean {
+  const defaults = initialClipEditForVideoType(videoType)
+  return LAYOUT_FIELDS.every((field) => (edit[field] ?? false) === (defaults[field] ?? false))
+}
+
 /**
  * Graft the result of a reframe analysis onto the current copy of a clip.
  *
- * The analysis owns the focus track, the content classification and the
- * layout defaults it derives from them (crop vs letterbox, auto vs manual
- * framing, the starting focus and whether auto zoom makes sense). Everything
- * else — title, trim, caption style, B-roll, the social caption — belongs to
- * whoever has been editing the clip in the meantime and is kept from
- * `current`. Used on both sides of the IPC boundary so the renderer's local
- * state and the saved project converge on the same clip.
+ * The analysis owns the focus track and the content classification, which
+ * are always taken. It also proposes layout defaults (crop vs letterbox,
+ * auto vs manual framing, the starting focus, whether auto zoom makes sense)
+ * — those are applied only while the clip still has the layout it was
+ * created with; a user who picked letterbox or dragged the focus slider
+ * while waiting keeps their choice. Everything else — title, trim, caption
+ * style, B-roll, the social caption — belongs to whoever has been editing
+ * the clip and is kept from `current`. Used on both sides of the IPC
+ * boundary so the renderer's local state and the saved project converge on
+ * the same clip.
  */
-export function mergeReframeResult(current: Clip, analysed: Clip): Clip {
-  return {
+export function mergeReframeResult(current: Clip, analysed: Clip, videoType: VideoType): Clip {
+  const merged: Clip = {
     ...current,
     focusTrack: analysed.focusTrack,
     contentType: analysed.contentType,
-    reframeStatus: 'done',
+    reframeStatus: 'done'
+  }
+  if (!layoutUntouched(current.edit, videoType)) return merged
+  return {
+    ...merged,
     edit: {
       ...current.edit,
       reframeMode: analysed.edit.reframeMode,

--- a/src/shared/sentences.ts
+++ b/src/shared/sentences.ts
@@ -1,9 +1,143 @@
 import type { Transcript, TranscriptWord } from './types'
 import { wordsInRange } from './captionLayout'
 
+/**
+ * The sentence model of a transcript. Whisper's segments break wherever its
+ * decoder window happened to end — routinely mid-sentence — so anything that
+ * reasons about where a thought starts or stops (clip boundaries, the LLM's
+ * view of the transcript, the ending and opening reviews) works on sentences
+ * derived from word punctuation instead.
+ */
+
 /** True when spoken text ends a sentence (terminal punctuation). */
 export function endsSentence(text: string): boolean {
   return /[.!?]["']?$/.test(text.trim())
+}
+
+export interface Sentence {
+  /** Position in the transcript, 0-based. */
+  index: number
+  /** First word's start, in source seconds. */
+  start: number
+  /** Last word's end, in source seconds. */
+  end: number
+  text: string
+  words: TranscriptWord[]
+  /**
+   * Duration-weighted mean of the vocal energy of the Whisper segments the
+   * sentence spans (0..1 percentile); undefined when none were annotated.
+   */
+  energy?: number
+}
+
+/**
+ * A run of speech with no terminal punctuation for longer than this is not
+ * one sentence, whatever Whisper says — it is a speaker who does not pause
+ * for full stops, or a transcription that dropped them. Such runs are split
+ * at their longest pauses so they still offer clip boundaries.
+ */
+export const MAX_SENTENCE_SEC = 20
+/** Pauses shorter than this are not breath points worth splitting at. */
+const MIN_SPLIT_PAUSE_SEC = 0.3
+/** Neither half of a split may be shorter than this. */
+const MIN_SPLIT_HALF_SEC = 2
+
+interface TaggedWord {
+  word: TranscriptWord
+  energy?: number
+  endsHere: boolean
+}
+
+/** Split an over-long run at its longest pause, recursively. */
+function splitLongRun(run: TaggedWord[]): TaggedWord[][] {
+  const span = run[run.length - 1].word.end - run[0].word.start
+  if (span <= MAX_SENTENCE_SEC || run.length < 4) return [run]
+  let bestIndex = -1
+  let bestGap = MIN_SPLIT_PAUSE_SEC
+  for (let i = 1; i < run.length; i++) {
+    const gap = run[i].word.start - run[i - 1].word.end
+    const leftSpan = run[i - 1].word.end - run[0].word.start
+    const rightSpan = run[run.length - 1].word.end - run[i].word.start
+    if (gap > bestGap && leftSpan >= MIN_SPLIT_HALF_SEC && rightSpan >= MIN_SPLIT_HALF_SEC) {
+      bestGap = gap
+      bestIndex = i
+    }
+  }
+  if (bestIndex === -1) return [run]
+  return [...splitLongRun(run.slice(0, bestIndex)), ...splitLongRun(run.slice(bestIndex))]
+}
+
+function toSentence(run: TaggedWord[], index: number): Sentence {
+  const words = run.map((t) => t.word)
+  let energySum = 0
+  let energyWeight = 0
+  for (const t of run) {
+    if (t.energy === undefined) continue
+    const weight = Math.max(0.01, t.word.end - t.word.start)
+    energySum += t.energy * weight
+    energyWeight += weight
+  }
+  return {
+    index,
+    start: words[0].start,
+    end: words[words.length - 1].end,
+    text: words.map((w) => w.text).join(' '),
+    words,
+    energy: energyWeight > 0 ? Math.round((energySum / energyWeight) * 100) / 100 : undefined
+  }
+}
+
+/**
+ * Sentences of a transcript, in order. A sentence ends on a word with
+ * terminal punctuation — or on a Whisper segment's last word when the segment
+ * text carries the punctuation the word lost, which Whisper does now and
+ * then. Runs longer than MAX_SENTENCE_SEC are split at their longest pauses.
+ * Words cleared in the transcript editor (empty text) are skipped.
+ */
+export function transcriptSentences(transcript: Transcript): Sentence[] {
+  const tagged: TaggedWord[] = []
+  for (const seg of transcript.segments) {
+    const words = seg.words.filter((w) => w.text.length > 0)
+    const segmentEnds = endsSentence(seg.text)
+    words.forEach((word, i) => {
+      const last = i === words.length - 1
+      tagged.push({
+        word,
+        energy: seg.energy,
+        endsHere: endsSentence(word.text) || (last && segmentEnds)
+      })
+    })
+  }
+  tagged.sort((a, b) => a.word.start - b.word.start)
+
+  const runs: TaggedWord[][] = []
+  let current: TaggedWord[] = []
+  for (const t of tagged) {
+    current.push(t)
+    if (t.endsHere) {
+      runs.push(current)
+      current = []
+    }
+  }
+  if (current.length > 0) runs.push(current)
+
+  const split: TaggedWord[][] = []
+  for (const run of runs) split.push(...splitLongRun(run))
+  return split.map((run, index) => toSentence(run, index))
+}
+
+/** The sentence a moment falls inside (start <= t < end), or null between sentences. */
+export function sentenceAt(sentences: Sentence[], t: number): Sentence | null {
+  for (const s of sentences) {
+    if (t < s.start) return null
+    if (t < s.end) return s
+  }
+  return null
+}
+
+/** Sentences that overlap [from, to], in order. */
+export function sentencesInRange(sentences: Sentence[], from: number, to: number): Sentence[] {
+  return sentences.filter((s) => s.end > from && s.start < to)
 }
 
 /**
@@ -11,19 +145,7 @@ export function endsSentence(text: string): boolean {
  * than Whisper segment boundaries (segments often break mid-sentence).
  */
 export function sentenceEndTimes(transcript: Transcript): number[] {
-  const ends: number[] = []
-  for (const seg of transcript.segments) {
-    for (const w of seg.words) {
-      if (endsSentence(w.text)) ends.push(w.end)
-    }
-    // Whisper sometimes omits terminal punctuation on the last word but keeps
-    // it on the segment text.
-    const last = seg.words[seg.words.length - 1]
-    if (last && !endsSentence(last.text) && endsSentence(seg.text)) {
-      ends.push(last.end)
-    }
-  }
-  return [...new Set(ends)].sort((a, b) => a - b)
+  return [...new Set(transcriptSentences(transcript).map((s) => s.end))].sort((a, b) => a - b)
 }
 
 /**
@@ -33,18 +155,7 @@ export function sentenceEndTimes(transcript: Transcript): number[] {
  * hook-first start review move the start to a later sentence.
  */
 export function sentenceStartTimes(transcript: Transcript): number[] {
-  const starts: number[] = []
-  let atSentenceStart = true
-  for (const seg of transcript.segments) {
-    for (const w of seg.words) {
-      if (atSentenceStart) {
-        starts.push(w.start)
-        atSentenceStart = false
-      }
-      if (endsSentence(w.text)) atSentenceStart = true
-    }
-  }
-  return [...new Set(starts)].sort((a, b) => a - b)
+  return [...new Set(transcriptSentences(transcript).map((s) => s.start))].sort((a, b) => a - b)
 }
 
 export interface NormalizeClipEndOptions {

--- a/src/shared/tighten.ts
+++ b/src/shared/tighten.ts
@@ -19,6 +19,15 @@ const MAX_PAUSE_SEC = 0.7
 /** Breathing room kept around speech when a pause is trimmed. */
 const PRE_ROLL_SEC = 0.18
 const POST_ROLL_SEC = 0.3
+/**
+ * Room kept before the first word and after the last one. The clip's own
+ * boundaries already sit a little outside the speech (0.25 s pre-roll, 0.6 s
+ * post-roll from the highlight pass); tightening must not trim that away:
+ * the export's 0.4 s audio fade lives in the tail, and eating into it ducks
+ * the last syllable of every tightened clip.
+ */
+const HEAD_ROLL_SEC = 0.3
+const TAIL_ROLL_SEC = 0.7
 /** Ignore removals shorter than this — not worth a visible jump cut. */
 const MIN_REMOVAL_SEC = 0.35
 const MIN_SEGMENT_SEC = 0.25
@@ -86,6 +95,12 @@ export function computeKeptSegments(
 
   const kept = spaced.filter((s) => s.end - s.start >= MIN_SEGMENT_SEC)
   if (kept.length === 0) return null
+
+  // Breathing room at both ends of the clip (see HEAD_ROLL_SEC).
+  kept[0].start = Math.max(clipStart, Math.min(kept[0].start, words[0].start - HEAD_ROLL_SEC))
+  const lastWord = words[words.length - 1]
+  const tail = kept[kept.length - 1]
+  tail.end = Math.min(clipEnd, Math.max(tail.end, lastWord.end + TAIL_ROLL_SEC))
 
   const keptDuration = kept.reduce((sum, s) => sum + (s.end - s.start), 0)
   const removed = clipEnd - clipStart - keptDuration

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -63,6 +63,15 @@ export type VideoType = 'auto' | 'talking-head' | 'podcast' | 'webinar' | 'produ
 /** Auto = follow the AI face track; manual = fixed focusX slider. */
 export type FramingMode = 'auto' | 'manual'
 
+/**
+ * Whether the on-device reframe analysis (face tracking, active speaker
+ * detection, layout classification) has run for a clip. The pipeline runs it
+ * eagerly for the top-scoring clips only; the rest are 'pending' until the
+ * clip is opened in the editor or exported. Absent on projects saved before
+ * this existed, which loadProject treats as 'done'.
+ */
+export type ReframeStatus = 'pending' | 'done'
+
 /** One step of the focus track (t in source seconds). */
 export interface FocusKeyframe {
   t: number
@@ -146,6 +155,8 @@ export interface Clip {
   thumbnailPath: string | null
   /** AI face track for auto reframing; null when no usable faces were found. */
   focusTrack: FocusKeyframe[] | null
+  /** See ReframeStatus. Undefined means done (older projects). */
+  reframeStatus?: ReframeStatus
   /**
    * Whether the clip is mostly a talking head or a screencast/demo/slides.
    * Set during analysis; null on older projects until re-analysed.

--- a/tests/captionLayout.test.ts
+++ b/tests/captionLayout.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it } from 'vitest'
-import { groupWords, wordsInRange } from '@shared/captionLayout'
+import {
+  CAPTION_HOLD_SEC,
+  captionLayoutBudget,
+  groupDisplayEnd,
+  groupWords,
+  wordsInRange,
+  type CaptionLayoutBudget
+} from '@shared/captionLayout'
+import { getCaptionStyle } from '@shared/captionStyles'
 import { makeTranscript } from './helpers'
 import type { TranscriptWord } from '@shared/types'
 
 const word = (text: string, start: number, end: number): TranscriptWord => ({ text, start, end })
+
+/** A budget wide enough that only the word cap, pauses and punctuation break groups. */
+const wide = (maxWords: number): CaptionLayoutBudget => ({
+  maxWords,
+  lineWidthEm: 1000,
+  glyphWidthEm: 0.5,
+  maxLines: 2
+})
 
 describe('wordsInRange', () => {
   it('selects words whose midpoint falls inside the clip', () => {
@@ -38,26 +54,113 @@ describe('groupWords', () => {
       word('c', 0.6, 0.8),
       word('d', 0.9, 1.1)
     ]
-    const groups = groupWords(words, 3)
+    const groups = groupWords(words, wide(3))
     expect(groups.map((g) => g.words.length)).toEqual([3, 1])
   })
 
   it('breaks groups on long pauses', () => {
     const words = [word('before', 0, 0.3), word('after', 2, 2.3)]
-    const groups = groupWords(words, 5)
+    const groups = groupWords(words, wide(5))
     expect(groups.length).toBe(2)
   })
 
   it('breaks groups after sentence-ending punctuation', () => {
     const words = [word('done.', 0, 0.3), word('next', 0.5, 0.8)]
-    const groups = groupWords(words, 5)
+    const groups = groupWords(words, wide(5))
     expect(groups.length).toBe(2)
   })
 
   it('records group start/end from its words', () => {
     const words = [word('a', 1, 1.4), word('b', 1.5, 2)]
-    const [group] = groupWords(words, 5)
+    const [group] = groupWords(words, wide(5))
     expect(group.start).toBe(1)
     expect(group.end).toBe(2)
+  })
+
+  it('starts a new line when the next word would overflow the line budget', () => {
+    // Five letters at 0.5em = 2.5em per word plus a 0.26em space; a 5.5em
+    // line holds two words, the third has to drop down.
+    const words = [word('aaaaa', 0, 0.2), word('bbbbb', 0.3, 0.5), word('ccccc', 0.6, 0.8)]
+    const [group] = groupWords(words, { maxWords: 6, lineWidthEm: 5.5, glyphWidthEm: 0.5, maxLines: 2 })
+    expect(group.lines.map((l) => l.map((w) => w.text))).toEqual([['aaaaa', 'bbbbb'], ['ccccc']])
+    expect(group.words.map((w) => w.text)).toEqual(['aaaaa', 'bbbbb', 'ccccc'])
+  })
+
+  it('never uses a third line: the group breaks instead', () => {
+    const words = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2'].map((t, i) => word(t, i * 0.3, i * 0.3 + 0.2))
+    // One word per line (2 letters = 1em, line holds 1.2em).
+    const groups = groupWords(words, { maxWords: 10, lineWidthEm: 1.2, glyphWidthEm: 0.5, maxLines: 2 })
+    expect(groups.map((g) => g.lines.length)).toEqual([2, 2, 2])
+    expect(groups.every((g) => g.lines.every((l) => l.length === 1))).toBe(true)
+  })
+
+  it('gives a word wider than a whole line its own line rather than dropping it', () => {
+    const words = [word('a', 0, 0.2), word('supercalifragilistic', 0.3, 0.8), word('b', 0.9, 1)]
+    const groups = groupWords(words, { maxWords: 10, lineWidthEm: 3, glyphWidthEm: 0.5, maxLines: 2 })
+    const texts = groups.flatMap((g) => g.words.map((w) => w.text))
+    expect(texts).toEqual(['a', 'supercalifragilistic', 'b'])
+    const longLine = groups.flatMap((g) => g.lines).find((l) => l[0].text.startsWith('super'))
+    expect(longLine).toHaveLength(1)
+  })
+
+  it('lines always concatenate back to the group words, in order', () => {
+    const words = Array.from({ length: 40 }, (_, i) =>
+      word(i % 3 === 0 ? 'longerword' : 'go', i * 0.25, i * 0.25 + 0.2)
+    )
+    const groups = groupWords(words, { maxWords: 6, lineWidthEm: 6, glyphWidthEm: 0.5, maxLines: 2 })
+    for (const g of groups) expect(g.lines.flat()).toEqual(g.words)
+    expect(groups.flatMap((g) => g.words)).toEqual(words)
+  })
+})
+
+describe('captionLayoutBudget', () => {
+  it('fits far fewer characters on a 9:16 frame than on 16:9 at the same style', () => {
+    const style = getCaptionStyle('beast')
+    const vertical = captionLayoutBudget(style, 9 / 16)
+    const wide = captionLayoutBudget(style, 16 / 9)
+    expect(wide.lineWidthEm).toBeGreaterThan(vertical.lineWidthEm * 3)
+    expect(vertical.maxWords).toBe(style.wordsPerGroup)
+    expect(vertical.maxLines).toBe(2)
+  })
+
+  it('keeps a vertical Beast caption to roughly twenty characters per line', () => {
+    // Anton at 5.2% of the frame height on a 1080-wide frame: about 21 glyphs.
+    const budget = captionLayoutBudget(getCaptionStyle('beast'), 9 / 16)
+    const chars = budget.lineWidthEm / budget.glyphWidthEm
+    expect(chars).toBeGreaterThan(17)
+    expect(chars).toBeLessThan(24)
+  })
+
+  it('uses the wider uppercase glyph average for shouting styles', () => {
+    const shouting = captionLayoutBudget(getCaptionStyle('crimson'), 1) // Poppins, uppercase
+    const quiet = captionLayoutBudget(getCaptionStyle('karaoke'), 1) // Poppins, mixed case
+    expect(shouting.glyphWidthEm).toBeGreaterThan(quiet.glyphWidthEm)
+  })
+
+  it('falls back to a conservative width for unknown (uploaded) fonts', () => {
+    const custom = captionLayoutBudget({ ...getCaptionStyle('karaoke'), fontFamily: 'My Brand Font' }, 1)
+    const known = captionLayoutBudget(getCaptionStyle('karaoke'), 1)
+    expect(custom.glyphWidthEm).toBeGreaterThan(known.glyphWidthEm)
+  })
+})
+
+describe('groupDisplayEnd', () => {
+  const groups = groupWords(
+    [word('one', 0, 0.3), word('two.', 0.4, 0.7), word('three', 5, 5.3), word('four', 5.4, 5.7)],
+    wide(4)
+  )
+
+  it('holds a finished group on screen for the hold time', () => {
+    expect(groups).toHaveLength(2)
+    expect(groupDisplayEnd(groups, 0, 100)).toBeCloseTo(0.7 + CAPTION_HOLD_SEC)
+  })
+
+  it('never holds into the next group', () => {
+    const close = groupWords([word('a.', 0, 0.3), word('b', 0.6, 0.9)], wide(4))
+    expect(groupDisplayEnd(close, 0, 100)).toBe(0.6)
+  })
+
+  it('never holds past the clip end', () => {
+    expect(groupDisplayEnd(groups, 1, 6)).toBe(6)
   })
 })

--- a/tests/captions.test.ts
+++ b/tests/captions.test.ts
@@ -22,9 +22,10 @@ describe('buildAss', () => {
   it('centres every caption block on the style anchor line, matching the preview', () => {
     const ass = buildAss(transcript, base)
     // Beast anchors at 72% of the frame height; \\an5 centres the block there.
-    expect(ass).toContain('{\\an5\\pos(540,1382)}')
-    // Wrapping is ours, not libass's: no auto-wrap, middle-centre style.
-    expect(ass).toContain('WrapStyle: 2')
+    expect(ass).toContain('{\\an5\\q2\\pos(540,1382)}')
+    // Caption wrapping is ours (\\q2 per event); the script keeps smart
+    // wrapping so the hook title, which has no explicit breaks, still wraps.
+    expect(ass).toContain('WrapStyle: 0')
     expect(ass).toMatch(/Style: Caption,[^\n]*,1,3.2,1,5,54,54,0,1/)
   })
 
@@ -69,6 +70,13 @@ describe('buildAss', () => {
     const ass = buildAss(transcript, { ...base, title: 'The Hook' })
     expect(ass).toContain('Dialogue: 1,')
     expect(ass).toContain('The Hook')
+  })
+
+  it('leaves the hook title free to wrap inside its margins', () => {
+    const ass = buildAss(transcript, { ...base, title: 'A long hook that must wrap onto two lines' })
+    const title = ass.split('\n').find((l) => l.startsWith('Dialogue: 1,'))!
+    expect(title).not.toContain('\\q2')
+    expect(title).not.toContain('\\N')
   })
 
   it('escapes ASS control characters in words', () => {

--- a/tests/captions.test.ts
+++ b/tests/captions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { buildAss } from '../src/main/pipeline/captions'
 import { makeTranscript } from './helpers'
+import { CAPTION_HOLD_SEC } from '@shared/captionLayout'
 
 describe('buildAss', () => {
   const transcript = makeTranscript(['hello brave new world'], { wordSec: 0.5, gapSec: 0.1 })
@@ -16,6 +17,44 @@ describe('buildAss', () => {
     const ass = buildAss(transcript, base)
     const events = ass.split('\n').filter((l) => l.startsWith('Dialogue: 0,'))
     expect(events.length).toBe(4)
+  })
+
+  it('centres every caption block on the style anchor line, matching the preview', () => {
+    const ass = buildAss(transcript, base)
+    // Beast anchors at 72% of the frame height; \\an5 centres the block there.
+    expect(ass).toContain('{\\an5\\pos(540,1382)}')
+    // Wrapping is ours, not libass's: no auto-wrap, middle-centre style.
+    expect(ass).toContain('WrapStyle: 2')
+    expect(ass).toMatch(/Style: Caption,[^\n]*,1,3.2,1,5,54,54,0,1/)
+  })
+
+  it('breaks lines itself with \\N when a group needs two lines', () => {
+    // Seven short words in the small "whisper" style on a 9:16 frame lay out
+    // as two lines; the export must carry that break explicitly.
+    const t = makeTranscript(['captions that run long enough to wrap around'], {
+      wordSec: 0.3,
+      gapSec: 0.05
+    })
+    const ass = buildAss(t, { ...base, styleId: 'whisper', clipEnd: t.durationSec })
+    expect(ass).toContain('\\N')
+  })
+
+  it('holds the last word of a group on screen briefly, but never into the next group', () => {
+    const t = makeTranscript(['first line.', 'second line.'], {
+      wordSec: 0.5,
+      gapSec: 0.1,
+      sentenceGapSec: 4
+    })
+    const ass = buildAss(t, { ...base, clipEnd: t.durationSec })
+    const events = ass
+      .split('\n')
+      .filter((l) => l.startsWith('Dialogue: 0,'))
+      .map((l) => l.split(',').slice(1, 3))
+    // Group one's last word is spoken 0.6-1.1s; its event runs on by the hold.
+    expect(events[1]).toEqual(['0:00:00.60', '0:00:02.60'])
+    expect(CAPTION_HOLD_SEC).toBe(1.5)
+    // The next group's first word starts at 5.2s, well after the hold ended.
+    expect(events[2][0]).toBe('0:00:05.20')
   })
 
   it('re-bases event times to the clip start', () => {

--- a/tests/clipMetrics.test.ts
+++ b/tests/clipMetrics.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { analyzeClipBoundaries, summarizeBoundaries } from '@shared/clipMetrics'
+import { makeTranscript } from './helpers'
+
+describe('analyzeClipBoundaries', () => {
+  // Words are 0.3 s with 0.1 s gaps; sentences 0.4 s apart.
+  const transcript = makeTranscript(['One two three.', 'Four five six.', 'Seven eight nine.'])
+  const words = transcript.segments.flatMap((s) => s.words)
+
+  it('reports a clean clip as clean', () => {
+    const start = words[3].start - 0.25 // "Four"
+    const end = words[8].end + 0.6 // "nine."
+    const r = analyzeClipBoundaries(transcript, start, end)
+    expect(r.startsMidSentence).toBe(false)
+    expect(r.endsMidSentence).toBe(false)
+    expect(r.leadInSec).toBeCloseTo(0.25)
+    expect(r.tailSec).toBeCloseTo(0.6)
+    expect(r.openingSentence).toBe('Four five six.')
+    expect(r.closingSentence).toBe('Seven eight nine.')
+    expect(r.wordCount).toBe(6)
+  })
+
+  it('flags mid-sentence starts and ends', () => {
+    const start = words[4].start - 0.1 // "five"
+    const end = words[7].end + 0.2 // "eight"
+    const r = analyzeClipBoundaries(transcript, start, end)
+    expect(r.startsMidSentence).toBe(true)
+    expect(r.endsMidSentence).toBe(true)
+  })
+
+  it('handles a clip with no words', () => {
+    const r = analyzeClipBoundaries(transcript, 50, 60)
+    expect(r.wordCount).toBe(0)
+    expect(r.startsMidSentence).toBeNull()
+    expect(r.tailSec).toBeNull()
+  })
+})
+
+describe('summarizeBoundaries', () => {
+  it('counts the failure modes and describes the length spread', () => {
+    const base = {
+      wordCount: 10,
+      leadInSec: 0.25,
+      startsMidSentence: false,
+      endsMidSentence: false,
+      openingSentence: 'a',
+      closingSentence: 'b'
+    }
+    const s = summarizeBoundaries([
+      { ...base, durationSec: 20, tailSec: 0.6 },
+      { ...base, durationSec: 30, tailSec: 0.1, startsMidSentence: true },
+      { ...base, durationSec: 40, tailSec: 3, endsMidSentence: true }
+    ])
+    expect(s.clips).toBe(3)
+    expect(s.midSentenceStarts).toBe(1)
+    expect(s.midSentenceEnds).toBe(1)
+    expect(s.clippedTails).toBe(1)
+    expect(s.deadAirTails).toBe(1)
+    expect(s.medianDurationSec).toBe(30)
+    expect(s.meanDurationSec).toBe(30)
+    expect(s.minDurationSec).toBe(20)
+    expect(s.maxDurationSec).toBe(40)
+  })
+
+  it('is well defined on no clips', () => {
+    expect(summarizeBoundaries([]).clips).toBe(0)
+  })
+})

--- a/tests/highlights.test.ts
+++ b/tests/highlights.test.ts
@@ -173,6 +173,22 @@ describe('snapClipStart / snapClipEnd', () => {
     expect(snapClipStart(gap, sentences, wordStarts)).toBe(sentences[1].start)
   })
 
+  it('stays inside a long sentence near its end instead of jumping to the next one', () => {
+    // 15 s sentence followed by another; a start 1.6 s before the next
+    // sentence begins is still this sentence's thought.
+    const words = Array.from({ length: 30 }, (_, i) => ({ text: 'w', start: i * 0.5, end: i * 0.5 + 0.4 }))
+    words[29].text = 'w.'
+    const more = Array.from({ length: 6 }, (_, i) => ({ text: 'n', start: 15.4 + i * 0.5, end: 15.8 + i * 0.5 }))
+    more[5].text = 'n.'
+    const all = [...words, ...more]
+    const t = { language: 'english', durationSec: 20, segments: [{ id: 0, text: 'x.', start: 0, end: 20, words: all }] }
+    const s = transcriptSentences(t)
+    expect(s.map((x) => x.start)).toEqual([0, 15.4])
+    const snapped = snapClipStart(13.8, s, all.map((w) => w.start))
+    expect(snapped).toBeLessThan(15.4)
+    expect(snapped).toBeCloseTo(14.0, 5)
+  })
+
   it('falls back to a word boundary deep inside a long sentence', () => {
     const words = Array.from({ length: 30 }, (_, i) => ({ text: 'w', start: i * 0.5, end: i * 0.5 + 0.4 }))
     const long = { language: 'english', durationSec: 15, segments: [{ id: 0, text: 'x.', start: 0, end: 15, words }] }

--- a/tests/highlights.test.ts
+++ b/tests/highlights.test.ts
@@ -3,8 +3,13 @@ import {
   applyRefinedEnding,
   applyRefinedStart,
   dedupeClips,
+  formatTranscriptForModel,
+  snapClipEnd,
+  snapClipStart,
   targetClipCount
 } from '../src/main/pipeline/highlights'
+import { transcriptSentences } from '@shared/sentences'
+import { makeTranscript } from './helpers'
 import { DEFAULT_CAPTION_STYLE_ID } from '@shared/captionStyles'
 import type { Clip } from '@shared/types'
 
@@ -143,5 +148,65 @@ describe('applyRefinedStart', () => {
     )
     // Nonsense values.
     expect(applyRefinedStart(original, Number.NaN, sentenceStarts)).toBe(original)
+  })
+})
+
+describe('snapClipStart / snapClipEnd', () => {
+  // Three sentences of five words at 0.4 s per word: [0,1.9] [2.3,4.2] [4.6,6.5] …
+  const transcript = makeTranscript(
+    ['one two three four five.', 'six seven eight nine ten.', 'eleven twelve thirteen fourteen fifteen.', 'sixteen seventeen eighteen nineteen twenty.'],
+    { wordSec: 0.3, gapSec: 0.1, sentenceGapSec: 0.4 }
+  )
+  const sentences = transcriptSentences(transcript)
+  const words = sentences.flatMap((s) => s.words)
+  const wordStarts = words.map((w) => w.start)
+  const wordEnds = words.map((w) => w.end)
+
+  it('opens the sentence the moment falls inside rather than skipping it', () => {
+    // 1.0 s into sentence 1 (which starts at 2.3): nearest-boundary logic
+    // would have jumped forward to sentence 2; we open sentence 1.
+    expect(snapClipStart(sentences[1].start + 1.0, sentences, wordStarts)).toBe(sentences[1].start)
+  })
+
+  it('moves a start that lands in a pause onto the next sentence', () => {
+    const gap = (sentences[0].end + sentences[1].start) / 2
+    expect(snapClipStart(gap, sentences, wordStarts)).toBe(sentences[1].start)
+  })
+
+  it('falls back to a word boundary deep inside a long sentence', () => {
+    const words = Array.from({ length: 30 }, (_, i) => ({ text: 'w', start: i * 0.5, end: i * 0.5 + 0.4 }))
+    const long = { language: 'english', durationSec: 15, segments: [{ id: 0, text: 'x.', start: 0, end: 15, words }] }
+    long.segments[0].words[29].text = 'w.'
+    const s = transcriptSentences(long)
+    expect(s).toHaveLength(1)
+    // 6 s in: too far from the start to rewind, so the nearest word start.
+    expect(snapClipStart(6.1, s, words.map((w) => w.start))).toBe(6)
+  })
+
+  it('completes the sentence a moment ends inside', () => {
+    expect(snapClipEnd(sentences[1].start + 0.5, sentences, wordEnds)).toBe(sentences[1].end)
+  })
+
+  it('closes on the sentence just finished when the moment lands in the pause after it', () => {
+    const gap = sentences[1].end + 0.2
+    expect(snapClipEnd(gap, sentences, wordEnds)).toBe(sentences[1].end)
+  })
+
+  it('leaves the model exactly on a sentence end alone', () => {
+    expect(snapClipEnd(sentences[2].end, sentences, wordEnds)).toBe(sentences[2].end)
+  })
+})
+
+describe('formatTranscriptForModel', () => {
+  it('writes one sentence per line with start/end and delivery tags', () => {
+    const t = makeTranscript(['Loud one.', 'Middle one.', 'Quiet one.'])
+    t.segments[0].energy = 0.95
+    t.segments[1].energy = 0.5
+    t.segments[2].energy = 0.1
+    const lines = formatTranscriptForModel(transcriptSentences(t)).split('\n')
+    expect(lines).toHaveLength(3)
+    expect(lines[0]).toMatch(/^\[0\.0s - 0\.7s\] Loud one\. \[delivery: energetic\]$/)
+    expect(lines[1]).not.toContain('[delivery')
+    expect(lines[2]).toContain('[delivery: subdued]')
   })
 })

--- a/tests/highlightsFlow.test.ts
+++ b/tests/highlightsFlow.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { detectHighlights } from '../src/main/pipeline/highlights'
+import { analyzeClipBoundaries } from '@shared/clipMetrics'
+import { transcriptSentences } from '@shared/sentences'
+import { makeTranscript } from './helpers'
+
+/**
+ * Drives the whole highlight pass — model request, boundary snapping,
+ * sentence completion, the ending review, dedupe — against a scripted model.
+ * chatJSON goes through global fetch, so a stub that answers each schema by
+ * name stands in for OpenAI; the requests it receives are kept so the test
+ * can check what the model was shown.
+ */
+
+interface Captured {
+  schema: string
+  user: string
+}
+
+function chatReply(payload: unknown): Response {
+  return new Response(
+    JSON.stringify({ choices: [{ message: { content: JSON.stringify(payload) } }] }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  )
+}
+
+describe('detectHighlights end to end (scripted model)', () => {
+  // Twelve sentences of six words: each 2.3 s of speech, 0.4 s apart, so
+  // sentence k starts at 2.7k and ends at 2.7k + 2.3.
+  const transcript = makeTranscript(
+    Array.from({ length: 12 }, (_, i) => `sentence ${i} word three four five.`),
+    { wordSec: 0.3, gapSec: 0.1, sentenceGapSec: 0.4 }
+  )
+  const sentences = transcriptSentences(transcript)
+  const VIDEO = transcript.durationSec + 5
+  const captured: Captured[] = []
+  let answers: Record<string, (body: Record<string, unknown>) => unknown>
+
+  beforeEach(() => {
+    captured.length = 0
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>
+        response_format: { json_schema: { name: string } }
+      }
+      const schema = body.response_format.json_schema.name
+      captured.push({ schema, user: body.messages.find((m) => m.role === 'user')?.content ?? '' })
+      const answer = answers[schema]
+      if (!answer) throw new Error(`unexpected schema ${schema}`)
+      return chatReply(answer(body as unknown as Record<string, unknown>))
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const raw = (start: number, end: number, score: number, title = 'A clip') => ({
+    start,
+    end,
+    title,
+    hook: 'hook',
+    summary: 'summary',
+    payoff: 'payoff',
+    virality_score: score,
+    virality_reason: 'because',
+    hashtags: ['a', 'b', 'c']
+  })
+
+  it('shows the model one sentence per line with timestamps', async () => {
+    answers = {
+      viral_clips: () => ({ clips: [raw(sentences[1].start, sentences[5].end, 80)] }),
+      clip_endings: () => ({ endings: [{ index: 0, ends_with_payoff: true, better_end: sentences[5].end, reason: 'lands' }] })
+    }
+    await detectHighlights('key', 'model', transcript, { prompt: '', clipLength: 'auto', broll: false, hookFirst: false, videoType: 'auto' }, VIDEO)
+    const request = captured.find((c) => c.schema === 'viral_clips')!
+    const lines = request.user.split('\n').filter((l) => /^\[\d+\.\ds - \d+\.\ds\] /.test(l))
+    expect(lines).toHaveLength(sentences.length)
+    expect(lines[3]).toBe(`[${sentences[3].start.toFixed(1)}s - ${sentences[3].end.toFixed(1)}s] ${sentences[3].text}`)
+  })
+
+  it('lands mid-sentence model boundaries on sentence boundaries with pre- and post-roll', async () => {
+    answers = {
+      viral_clips: () => ({
+        // 1 s into sentence 1, 0.5 s into sentence 5.
+        clips: [raw(sentences[1].start + 1.0, sentences[5].start + 0.5, 80)]
+      }),
+      clip_endings: () => ({ endings: [{ index: 0, ends_with_payoff: true, better_end: 0, reason: 'lands' }] })
+    }
+    const [clip] = await detectHighlights('key', 'model', transcript, { prompt: '', clipLength: 'auto', broll: false, hookFirst: false, videoType: 'auto' }, VIDEO)
+    expect(clip.suggestedStart).toBeCloseTo(sentences[1].start - 0.25, 5)
+    expect(clip.suggestedEnd).toBeCloseTo(sentences[5].end + 0.6, 5)
+    const report = analyzeClipBoundaries(transcript, clip.edit.start, clip.edit.end)
+    expect(report.startsMidSentence).toBe(false)
+    expect(report.endsMidSentence).toBe(false)
+    expect(report.openingSentence).toBe(sentences[1].text)
+    expect(report.closingSentence).toBe(sentences[5].text)
+  })
+
+  it('extends a clip whose ending the review judges as setup', async () => {
+    answers = {
+      viral_clips: () => ({ clips: [raw(sentences[2].start, sentences[6].end, 80)] }),
+      clip_endings: () => ({
+        endings: [{ index: 0, ends_with_payoff: false, better_end: sentences[7].end, reason: 'the payoff is the next line' }]
+      })
+    }
+    const [clip] = await detectHighlights('key', 'model', transcript, { prompt: '', clipLength: 'auto', broll: false, hookFirst: false, videoType: 'auto' }, VIDEO)
+    expect(clip.suggestedEnd).toBeCloseTo(sentences[7].end + 0.6, 5)
+    // The review saw the closing sentences tagged with their real end times.
+    const review = captured.find((c) => c.schema === 'clip_endings')!
+    expect(review.user).toContain(`[ends ${sentences[6].end.toFixed(1)}s] ${sentences[6].text}`)
+    expect(review.user).toContain(`[ends ${sentences[7].end.toFixed(1)}s] ${sentences[7].text}`)
+  })
+
+  it('advances a clip opening onto its hook sentence when asked to', async () => {
+    answers = {
+      viral_clips: () => ({ clips: [raw(sentences[1].start, sentences[8].end, 80)] }),
+      clip_endings: () => ({ endings: [{ index: 0, ends_with_payoff: true, better_end: 0, reason: 'lands' }] }),
+      clip_openings: () => ({
+        starts: [{ index: 0, opens_with_hook: false, better_start: sentences[3].start, reason: 'throat clearing' }]
+      })
+    }
+    const [clip] = await detectHighlights('key', 'model', transcript, { prompt: '', clipLength: 'auto', broll: false, hookFirst: true, videoType: 'auto' }, VIDEO)
+    expect(clip.suggestedStart).toBeCloseTo(sentences[3].start - 0.25, 5)
+    const review = captured.find((c) => c.schema === 'clip_openings')!
+    expect(review.user).toContain(`[starts ${sentences[1].start.toFixed(1)}s] ${sentences[1].text}`)
+  })
+
+  it('drops near-duplicate moments and keeps clips inside the video', async () => {
+    answers = {
+      viral_clips: () => ({
+        clips: [
+          raw(sentences[1].start, sentences[5].end, 90, 'winner'),
+          raw(sentences[2].start, sentences[5].end, 70, 'dupe'),
+          raw(sentences[7].start, VIDEO + 40, 60, 'overruns')
+        ]
+      }),
+      clip_endings: () => ({ endings: [] })
+    }
+    const clips = await detectHighlights('key', 'model', transcript, { prompt: '', clipLength: 'auto', broll: false, hookFirst: false, videoType: 'auto' }, VIDEO)
+    expect(clips.map((c) => c.title)).toEqual(['winner', 'overruns'])
+    expect(clips[1].suggestedEnd).toBeLessThanOrEqual(VIDEO)
+  })
+})

--- a/tests/lazyReframe.test.ts
+++ b/tests/lazyReframe.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { Clip, Project } from '@shared/types'
+
+/**
+ * Integration test for on-demand reframe analysis: a project with a pending
+ * clip on disk, a real (synthetic) video, the real UltraFace + LR-ASD path.
+ * The synthetic footage has no faces, so the analysis must land as a
+ * screencast verdict — what matters here is the plumbing: the analysis runs
+ * once, persists, merges onto concurrent edits and is a no-op afterwards.
+ */
+
+// Hoisted above the imports (vi.mock needs the path), so it cannot use them.
+const { userData } = await vi.hoisted(async () => {
+  const os = await import('node:os')
+  const path = await import('node:path')
+  return { userData: path.join(os.tmpdir(), `clipforge-lazy-reframe-${process.pid}-${Date.now()}`) }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => userData,
+    getAppPath: () => process.cwd(),
+    isPackaged: false
+  }
+}))
+
+const { ensureClipReframe } = await import('../src/main/pipeline/reframe')
+const { loadProject, projectDir } = await import('../src/main/projects')
+const { runFfmpeg, probeVideo } = await import('../src/main/pipeline/ffmpeg')
+
+const PROJECT_ID = 'lazy-reframe-test'
+
+function pendingClip(id: string, end: number): Clip {
+  return {
+    id,
+    suggestedStart: 0,
+    suggestedEnd: end,
+    title: 'Untouched title',
+    hook: '',
+    summary: '',
+    viralityScore: 50,
+    viralityReason: '',
+    visualSummary: null,
+    hashtags: [],
+    thumbnailPath: null,
+    focusTrack: null,
+    reframeStatus: 'pending',
+    contentType: null,
+    broll: [],
+    edit: {
+      aspect: '9:16',
+      reframeMode: 'crop',
+      framing: 'manual',
+      tightenCuts: true,
+      autoZoom: true,
+      focusX: 0.5,
+      captionsEnabled: true,
+      captionStyleId: 'beast',
+      showTitle: false,
+      start: 0,
+      end
+    }
+  }
+}
+
+async function writeProject(project: Project): Promise<void> {
+  await writeFile(join(projectDir(project.id), 'project.json'), JSON.stringify(project), 'utf8')
+}
+
+describe('ensureClipReframe', () => {
+  let project: Project
+
+  beforeAll(async () => {
+    const dir = projectDir(PROJECT_ID)
+    await mkdir(dir, { recursive: true })
+    const videoPath = join(dir, 'source.mp4')
+    // Three seconds of moving test pattern with a tone: decodes fast, has no faces.
+    await runFfmpeg([
+      '-f', 'lavfi', '-i', 'testsrc2=size=640x360:rate=25:duration=3',
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=3',
+      '-c:v', 'libx264', '-preset', 'ultrafast', '-pix_fmt', 'yuv420p',
+      '-c:a', 'aac', '-shortest', videoPath
+    ])
+    const video = await probeVideo(videoPath)
+    project = {
+      id: PROJECT_ID,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      name: 'Lazy reframe',
+      video,
+      transcript: null,
+      clips: [pendingClip('faces', video.durationSec), pendingClip('demo', video.durationSec)],
+      prompt: '',
+      videoType: 'podcast'
+    }
+    await writeProject(project)
+  }, 60_000)
+
+  afterAll(async () => {
+    await rm(userData, { recursive: true, force: true })
+  })
+
+  it('analyses a pending clip once, persists it and shares the run between callers', async () => {
+    const [a, b] = await Promise.all([
+      ensureClipReframe(PROJECT_ID, 'faces'),
+      ensureClipReframe(PROJECT_ID, 'faces')
+    ])
+    expect(a).toBe(b)
+    const done = a.clips.find((c) => c.id === 'faces')!
+    expect(done.reframeStatus).toBe('done')
+    // No faces in a test pattern: classified as a screencast and letterboxed.
+    expect(done.contentType).toBe('screencast')
+    expect(done.focusTrack).toBeNull()
+    expect(done.edit.reframeMode).toBe('fit-letterbox')
+    expect(done.edit.autoZoom).toBe(false)
+
+    const onDisk = JSON.parse(
+      await readFile(join(projectDir(PROJECT_ID), 'project.json'), 'utf8')
+    ) as Project
+    expect(onDisk.clips.find((c) => c.id === 'faces')?.reframeStatus).toBe('done')
+    // The other clip is untouched.
+    expect(onDisk.clips.find((c) => c.id === 'demo')?.reframeStatus).toBe('pending')
+  }, 60_000)
+
+  it('is a no-op once analysed', async () => {
+    const before = await loadProject(PROJECT_ID)
+    const after = await ensureClipReframe(PROJECT_ID, 'faces')
+    expect(after.clips.find((c) => c.id === 'faces')).toEqual(before.clips.find((c) => c.id === 'faces'))
+  })
+
+  it('keeps edits saved while the analysis was running', async () => {
+    // Start the analysis, then change the title on disk before it lands.
+    const running = ensureClipReframe(PROJECT_ID, 'demo')
+    const { updateProject } = await import('../src/main/projects')
+    await updateProject(PROJECT_ID, (fresh) => {
+      const clip = fresh.clips.find((c) => c.id === 'demo')!
+      clip.title = 'Renamed mid-analysis'
+      clip.edit.captionStyleId = 'neon'
+    })
+    const result = await running
+    const clip = result.clips.find((c) => c.id === 'demo')!
+    expect(clip.reframeStatus).toBe('done')
+    expect(clip.title).toBe('Renamed mid-analysis')
+    expect(clip.edit.captionStyleId).toBe('neon')
+  }, 60_000)
+
+  it('returns the project unchanged for an unknown clip', async () => {
+    const result = await ensureClipReframe(PROJECT_ID, 'nope')
+    expect(result.clips.map((c) => c.id)).toEqual(['faces', 'demo'])
+  })
+})

--- a/tests/lazyReframe.test.ts
+++ b/tests/lazyReframe.test.ts
@@ -91,7 +91,12 @@ describe('ensureClipReframe', () => {
       name: 'Lazy reframe',
       video,
       transcript: null,
-      clips: [pendingClip('faces', video.durationSec), pendingClip('demo', video.durationSec)],
+      clips: [
+        pendingClip('faces', video.durationSec),
+        pendingClip('demo', video.durationSec),
+        pendingClip('shared', video.durationSec),
+        pendingClip('cancelled', video.durationSec)
+      ],
       prompt: '',
       videoType: 'podcast'
     }
@@ -146,8 +151,33 @@ describe('ensureClipReframe', () => {
     expect(clip.edit.captionStyleId).toBe('neon')
   }, 60_000)
 
+  it('lets one caller cancel without stranding another waiting on the same clip', async () => {
+    const exportSide = new AbortController()
+    const cancelled = ensureClipReframe(PROJECT_ID, 'shared', exportSide.signal)
+    const editorSide = ensureClipReframe(PROJECT_ID, 'shared')
+    exportSide.abort()
+    await expect(cancelled).rejects.toThrow()
+    const result = await editorSide
+    expect(result.clips.find((c) => c.id === 'shared')?.reframeStatus).toBe('done')
+  }, 60_000)
+
+  it('cancels the run when every caller has aborted, leaving the clip pending', async () => {
+    const a = new AbortController()
+    const b = new AbortController()
+    const first = ensureClipReframe(PROJECT_ID, 'cancelled', a.signal)
+    const second = ensureClipReframe(PROJECT_ID, 'cancelled', b.signal)
+    a.abort()
+    b.abort()
+    await expect(first).rejects.toThrow()
+    await expect(second).rejects.toThrow()
+    // Give the aborted ffmpeg a moment to exit, then check nothing landed.
+    await new Promise((r) => setTimeout(r, 300))
+    const onDisk = await loadProject(PROJECT_ID)
+    expect(onDisk.clips.find((c) => c.id === 'cancelled')?.reframeStatus).toBe('pending')
+  }, 60_000)
+
   it('returns the project unchanged for an unknown clip', async () => {
     const result = await ensureClipReframe(PROJECT_ID, 'nope')
-    expect(result.clips.map((c) => c.id)).toEqual(['faces', 'demo'])
+    expect(result.clips.map((c) => c.id)).toEqual(['faces', 'demo', 'shared', 'cancelled'])
   })
 })

--- a/tests/loudness.test.ts
+++ b/tests/loudness.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { loudnormFilter, MEASURE_FILTER, parseLoudnormStats } from '../src/main/pipeline/loudness'
+import {
+  loudnormFilter,
+  MAX_GAIN_DB,
+  MEASURE_FILTER,
+  normalisationMode,
+  parseLoudnormStats
+} from '../src/main/pipeline/loudness'
 
 const STDERR = `Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'source.mp4':
   Duration: 00:00:30.00, start: 0.000000, bitrate: 2500 kb/s
@@ -45,11 +51,35 @@ describe('loudnormFilter', () => {
     expect(loudnormFilter(null)).toBe('loudnorm=I=-14:TP=-1.5:LRA=11')
   })
 
-  it('feeds the measurements back for linear normalisation', () => {
+  it('feeds the measurements back for linear normalisation when peaks allow', () => {
+    // -27.61 -> -14 needs +13.61 dB; TP -4.47 would land at +9.1, over the
+    // ceiling, so this source cannot take the loudnorm linear path.
     const stats = parseLoudnormStats(STDERR)!
-    expect(loudnormFilter(stats)).toBe(
-      'loudnorm=I=-14:TP=-1.5:LRA=11:measured_I=-27.61:measured_TP=-4.47:measured_LRA=18.06:measured_thresh=-39.20:offset=0.47:linear=true'
+    expect(normalisationMode(stats)).toBe('limited')
+    const quiet = { ...stats, inputTp: -16 }
+    expect(normalisationMode(quiet)).toBe('linear')
+    // The range target is raised to the measured range (18.06 -> 18.1):
+    // loudnorm refuses linear mode when the target is below the source.
+    expect(loudnormFilter(quiet)).toBe(
+      'loudnorm=I=-14:TP=-1.5:LRA=18.10:measured_I=-27.61:measured_TP=-16.00:measured_LRA=18.06:measured_thresh=-39.20:offset=0.47:linear=true'
     )
+  })
+
+  it('keeps the default range target for narrow-range sources', () => {
+    const stats = { inputI: -20, inputTp: -10, inputLra: 4.4, inputThresh: -31, targetOffset: 0.1 }
+    expect(loudnormFilter(stats)).toContain(':LRA=11.00:')
+  })
+
+  it('applies a plain gain into a limiter when the peak would exceed the ceiling', () => {
+    const stats = { inputI: -24, inputTp: -6, inputLra: 9, inputThresh: -35, targetOffset: 0.3 }
+    expect(normalisationMode(stats)).toBe('limited')
+    // +10 dB gain, limiter just under -1.5 dBTP, no auto-levelling.
+    expect(loudnormFilter(stats)).toBe('volume=10.00dB,alimiter=limit=0.7943:attack=5:release=50:level=false')
+  })
+
+  it('caps the limiter-path gain for broken, near-silent sources', () => {
+    const stats = { inputI: -60, inputTp: -20, inputLra: 5, inputThresh: -70, targetOffset: 0 }
+    expect(loudnormFilter(stats)).toContain(`volume=${MAX_GAIN_DB.toFixed(2)}dB`)
   })
 
   it('measures against the same targets it normalises to', () => {

--- a/tests/loudness.test.ts
+++ b/tests/loudness.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { loudnormFilter, MEASURE_FILTER, parseLoudnormStats } from '../src/main/pipeline/loudness'
+
+const STDERR = `Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'source.mp4':
+  Duration: 00:00:30.00, start: 0.000000, bitrate: 2500 kb/s
+[Parsed_loudnorm_0 @ 0x55d0] 
+{
+\t"input_i" : "-27.61",
+\t"input_tp" : "-4.47",
+\t"input_lra" : "18.06",
+\t"input_thresh" : "-39.20",
+\t"output_i" : "-22.03",
+\t"output_tp" : "-1.50",
+\t"output_lra" : "9.50",
+\t"output_thresh" : "-32.60",
+\t"normalization_type" : "dynamic",
+\t"target_offset" : "0.47"
+}
+`
+
+describe('parseLoudnormStats', () => {
+  it('reads the measurement block loudnorm prints on stderr', () => {
+    expect(parseLoudnormStats(STDERR)).toEqual({
+      inputI: -27.61,
+      inputTp: -4.47,
+      inputLra: 18.06,
+      inputThresh: -39.2,
+      targetOffset: 0.47
+    })
+  })
+
+  it('returns null for silent input (loudnorm reports -inf)', () => {
+    const silent = STDERR.replace('"-27.61"', '"-inf"')
+    expect(parseLoudnormStats(silent)).toBeNull()
+  })
+
+  it('returns null when there is no block at all', () => {
+    expect(parseLoudnormStats('ffmpeg version 6.1\nno audio here')).toBeNull()
+    expect(parseLoudnormStats('{ not json')).toBeNull()
+  })
+})
+
+describe('loudnormFilter', () => {
+  it('runs single-pass when nothing was measured', () => {
+    expect(loudnormFilter(null)).toBe('loudnorm=I=-14:TP=-1.5:LRA=11')
+  })
+
+  it('feeds the measurements back for linear normalisation', () => {
+    const stats = parseLoudnormStats(STDERR)!
+    expect(loudnormFilter(stats)).toBe(
+      'loudnorm=I=-14:TP=-1.5:LRA=11:measured_I=-27.61:measured_TP=-4.47:measured_LRA=18.06:measured_thresh=-39.20:offset=0.47:linear=true'
+    )
+  })
+
+  it('measures against the same targets it normalises to', () => {
+    expect(MEASURE_FILTER).toBe('loudnorm=I=-14:TP=-1.5:LRA=11:print_format=json')
+  })
+})

--- a/tests/reframe.test.ts
+++ b/tests/reframe.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EAGER_REFRAME_MAX,
+  EAGER_REFRAME_MIN,
+  EAGER_REFRAME_SCORE,
+  mergeReframeResult,
+  needsReframe,
+  selectEagerReframeIds
+} from '@shared/reframe'
+import type { Clip } from '@shared/types'
+
+function clip(id: string, score: number, overrides: Partial<Clip> = {}): Clip {
+  return {
+    id,
+    suggestedStart: 0,
+    suggestedEnd: 30,
+    title: id,
+    hook: '',
+    summary: '',
+    viralityScore: score,
+    viralityReason: '',
+    visualSummary: null,
+    hashtags: [],
+    thumbnailPath: null,
+    focusTrack: null,
+    reframeStatus: 'pending',
+    broll: [],
+    edit: {
+      aspect: '9:16',
+      reframeMode: 'crop',
+      framing: 'manual',
+      tightenCuts: true,
+      autoZoom: true,
+      focusX: 0.5,
+      captionsEnabled: true,
+      captionStyleId: 'beast',
+      showTitle: false,
+      start: 0,
+      end: 30
+    },
+    ...overrides
+  }
+}
+
+describe('selectEagerReframeIds', () => {
+  it('always takes the top clips however they score', () => {
+    const ranked = Array.from({ length: 20 }, (_, i) => clip(`c${i}`, 50 - i))
+    const eager = selectEagerReframeIds(ranked)
+    expect(eager.size).toBe(EAGER_REFRAME_MIN)
+    for (let i = 0; i < EAGER_REFRAME_MIN; i++) expect(eager.has(`c${i}`)).toBe(true)
+  })
+
+  it('extends the tier for exceptional scores, up to the cap', () => {
+    const ranked = Array.from({ length: 20 }, (_, i) => clip(`c${i}`, 95 - i)) // 95..76
+    const eager = selectEagerReframeIds(ranked)
+    // Scores 95..84 are at/above the threshold: twelve clips, exactly the cap.
+    expect(eager.size).toBe(EAGER_REFRAME_MAX)
+    expect(eager.has(`c${EAGER_REFRAME_MAX - 1}`)).toBe(true)
+    expect(eager.has(`c${EAGER_REFRAME_MAX}`)).toBe(false)
+  })
+
+  it('never exceeds the cap even when everything scores high', () => {
+    const ranked = Array.from({ length: 40 }, (_, i) => clip(`c${i}`, 99))
+    expect(selectEagerReframeIds(ranked).size).toBe(EAGER_REFRAME_MAX)
+  })
+
+  it('skips clips below the score threshold once the minimum is filled', () => {
+    const ranked = [
+      ...Array.from({ length: EAGER_REFRAME_MIN }, (_, i) => clip(`top${i}`, 90)),
+      clip('strong', EAGER_REFRAME_SCORE),
+      clip('weak', EAGER_REFRAME_SCORE - 1),
+      clip('strongLater', 99)
+    ]
+    const eager = selectEagerReframeIds(ranked)
+    expect(eager.has('strong')).toBe(true)
+    expect(eager.has('weak')).toBe(false)
+    // Ranked input is score-ordered, so a later high score cannot happen in
+    // practice; the rule still admits it, which keeps the function total.
+    expect(eager.has('strongLater')).toBe(true)
+  })
+
+  it('takes every clip when there are fewer than the minimum', () => {
+    const ranked = [clip('a', 10), clip('b', 5)]
+    expect(selectEagerReframeIds(ranked)).toEqual(new Set(['a', 'b']))
+  })
+})
+
+describe('needsReframe', () => {
+  it('is true only for pending clips', () => {
+    expect(needsReframe(clip('a', 50))).toBe(true)
+    expect(needsReframe(clip('a', 50, { reframeStatus: 'done' }))).toBe(false)
+    // Older projects never carried the field; loadProject fills 'done' in,
+    // but a bare clip object must still read as analysed.
+    expect(needsReframe(clip('a', 50, { reframeStatus: undefined }))).toBe(false)
+  })
+})
+
+describe('mergeReframeResult', () => {
+  const analysed = clip('a', 50, {
+    reframeStatus: 'done',
+    contentType: 'speaker',
+    focusTrack: [{ t: 0, x: 0.3, cut: true }],
+    edit: {
+      aspect: '9:16',
+      reframeMode: 'crop',
+      framing: 'auto',
+      tightenCuts: true,
+      autoZoom: true,
+      focusX: 0.3,
+      captionsEnabled: true,
+      captionStyleId: 'beast',
+      showTitle: false,
+      start: 0,
+      end: 30
+    }
+  })
+
+  it('takes the analysis-owned fields and layout from the analysed clip', () => {
+    const merged = mergeReframeResult(clip('a', 50), analysed)
+    expect(merged.reframeStatus).toBe('done')
+    expect(merged.contentType).toBe('speaker')
+    expect(merged.focusTrack).toEqual([{ t: 0, x: 0.3, cut: true }])
+    expect(merged.edit.framing).toBe('auto')
+    expect(merged.edit.focusX).toBe(0.3)
+  })
+
+  it('keeps everything the user may have edited meanwhile', () => {
+    const edited = clip('a', 50, {
+      title: 'Renamed while analysing',
+      caption: 'A social caption',
+      edit: {
+        aspect: '1:1',
+        reframeMode: 'crop',
+        framing: 'manual',
+        tightenCuts: false,
+        autoZoom: true,
+        focusX: 0.5,
+        captionsEnabled: false,
+        captionStyleId: 'neon',
+        captionFontFamily: 'My Brand Font',
+        showTitle: true,
+        start: 2,
+        end: 28
+      }
+    })
+    const merged = mergeReframeResult(edited, analysed)
+    expect(merged.title).toBe('Renamed while analysing')
+    expect(merged.caption).toBe('A social caption')
+    expect(merged.edit).toMatchObject({
+      aspect: '1:1',
+      tightenCuts: false,
+      captionsEnabled: false,
+      captionStyleId: 'neon',
+      captionFontFamily: 'My Brand Font',
+      showTitle: true,
+      start: 2,
+      end: 28
+    })
+  })
+
+  it('applies a screencast verdict as letterbox with no zoom', () => {
+    const screencast = clip('a', 50, {
+      reframeStatus: 'done',
+      contentType: 'screencast',
+      edit: { ...analysed.edit, reframeMode: 'fit-letterbox', framing: 'manual', focusX: 0.5, autoZoom: false }
+    })
+    const merged = mergeReframeResult(clip('a', 50), screencast)
+    expect(merged.edit.reframeMode).toBe('fit-letterbox')
+    expect(merged.edit.autoZoom).toBe(false)
+    expect(merged.focusTrack).toBeNull()
+  })
+})

--- a/tests/reframe.test.ts
+++ b/tests/reframe.test.ts
@@ -3,6 +3,7 @@ import {
   EAGER_REFRAME_MAX,
   EAGER_REFRAME_MIN,
   EAGER_REFRAME_SCORE,
+  layoutUntouched,
   mergeReframeResult,
   needsReframe,
   selectEagerReframeIds
@@ -116,7 +117,7 @@ describe('mergeReframeResult', () => {
   })
 
   it('takes the analysis-owned fields and layout from the analysed clip', () => {
-    const merged = mergeReframeResult(clip('a', 50), analysed)
+    const merged = mergeReframeResult(clip('a', 50), analysed, 'auto')
     expect(merged.reframeStatus).toBe('done')
     expect(merged.contentType).toBe('speaker')
     expect(merged.focusTrack).toEqual([{ t: 0, x: 0.3, cut: true }])
@@ -143,7 +144,10 @@ describe('mergeReframeResult', () => {
         end: 28
       }
     })
-    const merged = mergeReframeResult(edited, analysed)
+    const merged = mergeReframeResult(edited, analysed, 'auto')
+    // Layout was still the default, so the analysis layout is applied…
+    expect(merged.edit.framing).toBe('auto')
+    expect(merged.edit.focusX).toBe(0.3)
     expect(merged.title).toBe('Renamed while analysing')
     expect(merged.caption).toBe('A social caption')
     expect(merged.edit).toMatchObject({
@@ -164,9 +168,32 @@ describe('mergeReframeResult', () => {
       contentType: 'screencast',
       edit: { ...analysed.edit, reframeMode: 'fit-letterbox', framing: 'manual', focusX: 0.5, autoZoom: false }
     })
-    const merged = mergeReframeResult(clip('a', 50), screencast)
+    const merged = mergeReframeResult(clip('a', 50), screencast, 'auto')
     expect(merged.edit.reframeMode).toBe('fit-letterbox')
     expect(merged.edit.autoZoom).toBe(false)
     expect(merged.focusTrack).toBeNull()
+  })
+
+  it('leaves a layout the user chose while waiting alone, but still attaches the analysis', () => {
+    const chosen = clip('a', 50, {
+      edit: { ...clip('a', 50).edit, reframeMode: 'fit-letterbox', framing: 'manual', focusX: 0.5, autoZoom: false }
+    })
+    expect(layoutUntouched(chosen.edit, 'auto')).toBe(false)
+    const merged = mergeReframeResult(chosen, analysed, 'auto')
+    expect(merged.reframeStatus).toBe('done')
+    expect(merged.focusTrack).toEqual(analysed.focusTrack)
+    expect(merged.contentType).toBe('speaker')
+    expect(merged.edit.reframeMode).toBe('fit-letterbox')
+    expect(merged.edit.framing).toBe('manual')
+  })
+
+  it('judges "untouched" against the defaults of the project video type', () => {
+    // Webinar clips start with auto zoom off; that is untouched for a webinar
+    // but a deliberate change for a podcast.
+    const edit = { ...clip('a', 50).edit, autoZoom: false }
+    expect(layoutUntouched(edit, 'webinar')).toBe(true)
+    expect(layoutUntouched(edit, 'podcast')).toBe(false)
+    const slid = { ...clip('a', 50).edit, focusX: 0.8 }
+    expect(layoutUntouched(slid, 'auto')).toBe(false)
   })
 })

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -59,6 +59,23 @@ describe('buildFilterGraph', () => {
     expect(graph.filterComplex).toContain('afade=t=out:st=29.600:d=0.4')
   })
 
+  it('normalises loudness in single-pass mode when the source was not measured', () => {
+    const graph = buildFilterGraph(makeClip(), source, null, 30, null)
+    expect(graph.filterComplex).toContain('loudnorm=I=-14:TP=-1.5:LRA=11,aresample=48000')
+    expect(graph.filterComplex).not.toContain('measured_I')
+  })
+
+  it('normalises linearly from the measured loudness when available', () => {
+    const graph = buildFilterGraph(makeClip(), source, null, 30, null, {
+      loudness: { inputI: -23.4, inputTp: -6.1, inputLra: 9.2, inputThresh: -33.7, targetOffset: 0.3 }
+    })
+    expect(graph.filterComplex).toContain(
+      'loudnorm=I=-14:TP=-1.5:LRA=11:measured_I=-23.40:measured_TP=-6.10:measured_LRA=9.20:measured_thresh=-33.70:offset=0.30:linear=true,aresample=48000'
+    )
+    // The tail fade still follows the master chain.
+    expect(graph.filterComplex).toContain('linear=true,aresample=48000,afade=t=out')
+  })
+
   it('skips the fade on very short clips', () => {
     const graph = buildFilterGraph(makeClip(0, 1), source, null, 1, null)
     expect(graph.filterComplex).not.toContain('afade')

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -67,13 +67,21 @@ describe('buildFilterGraph', () => {
 
   it('normalises linearly from the measured loudness when available', () => {
     const graph = buildFilterGraph(makeClip(), source, null, 30, null, {
-      loudness: { inputI: -23.4, inputTp: -6.1, inputLra: 9.2, inputThresh: -33.7, targetOffset: 0.3 }
+      loudness: { inputI: -23.4, inputTp: -12.1, inputLra: 9.2, inputThresh: -33.7, targetOffset: 0.3 }
     })
     expect(graph.filterComplex).toContain(
-      'loudnorm=I=-14:TP=-1.5:LRA=11:measured_I=-23.40:measured_TP=-6.10:measured_LRA=9.20:measured_thresh=-33.70:offset=0.30:linear=true,aresample=48000'
+      'loudnorm=I=-14:TP=-1.5:LRA=11.00:measured_I=-23.40:measured_TP=-12.10:measured_LRA=9.20:measured_thresh=-33.70:offset=0.30:linear=true,aresample=48000'
     )
     // The tail fade still follows the master chain.
     expect(graph.filterComplex).toContain('linear=true,aresample=48000,afade=t=out')
+  })
+
+  it('gains into a limiter when a linear gain would clip the true peak', () => {
+    const graph = buildFilterGraph(makeClip(), source, null, 30, null, {
+      loudness: { inputI: -23.4, inputTp: -6.1, inputLra: 9.2, inputThresh: -33.7, targetOffset: 0.3 }
+    })
+    expect(graph.filterComplex).toContain('volume=9.40dB,alimiter=limit=0.7943:attack=5:release=50:level=false,aresample=48000')
+    expect(graph.filterComplex).not.toContain('loudnorm')
   })
 
   it('skips the fade on very short clips', () => {

--- a/tests/sentences.test.ts
+++ b/tests/sentences.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import type { Transcript } from '@shared/types'
+import type { Transcript, TranscriptWord } from '@shared/types'
 import {
   endsSentence,
   lastWordInClip,
+  MAX_SENTENCE_SEC,
   normalizeClipEnd,
+  sentenceAt,
   sentenceEndTimes,
-  sentenceStartTimes
+  sentenceStartTimes,
+  sentencesInRange,
+  transcriptSentences
 } from '../src/shared/sentences'
+import { makeTranscript } from './helpers'
 
 /** Two full sentences in one segment. */
 function twoSentences(): Transcript {
@@ -113,5 +118,90 @@ describe('normalizeClipEnd', () => {
   it('does not extend beyond the cap', () => {
     const end = normalizeClipEnd(0, 3.3, transcript, 20, { postRollSec, maxExtendSec: 0.5 })
     expect(end).toBe(3.3)
+  })
+})
+
+describe('transcriptSentences', () => {
+  it('splits on word punctuation, not Whisper segments', () => {
+    const sentences = transcriptSentences(transcriptEndingOnSo())
+    // The segment break after "so" is not a sentence break; the full stop is.
+    expect(sentences.map((s) => s.text)).toEqual(['and that is why it matters so much for everyone today.'])
+    expect(sentences[0].start).toBe(0)
+    expect(sentences[0].end).toBe(4.5)
+  })
+
+  it('numbers sentences in order and carries their words', () => {
+    const sentences = transcriptSentences(twoSentences())
+    expect(sentences.map((s) => s.index)).toEqual([0, 1])
+    expect(sentences[1].words.map((w) => w.text)).toEqual(['This', 'is', 'next.'])
+  })
+
+  it('trusts segment punctuation when the last word lost it', () => {
+    const t = makeTranscript(['no stop here', 'Second one.'])
+    t.segments[0].text = 'no stop here.'
+    expect(transcriptSentences(t).map((s) => s.text)).toEqual(['no stop here', 'Second one.'])
+  })
+
+  it('skips words cleared in the transcript editor', () => {
+    const t = makeTranscript(['keep this one.'])
+    t.segments[0].words[1].text = ''
+    expect(transcriptSentences(t)[0].text).toBe('keep one.')
+  })
+
+  it('splits an unpunctuated ramble at its longest pause', () => {
+    // 60 words, 0.5 s apart, no punctuation: one 30 s run. A 1.2 s pause sits
+    // two thirds of the way through and is the natural split.
+    const words: TranscriptWord[] = []
+    let t = 0
+    for (let i = 0; i < 60; i++) {
+      words.push({ text: 'word', start: t, end: t + 0.3 })
+      t += i === 39 ? 1.5 : 0.5
+    }
+    const transcript = {
+      language: 'english',
+      durationSec: t,
+      segments: [{ id: 0, text: 'x', start: 0, end: t, words }]
+    }
+    const sentences = transcriptSentences(transcript)
+    expect(sentences.length).toBeGreaterThanOrEqual(2)
+    expect(sentences.every((s) => s.end - s.start <= MAX_SENTENCE_SEC)).toBe(true)
+    // The split lands on the big pause.
+    expect(sentences.some((s) => Math.abs(s.start - words[40].start) < 1e-6)).toBe(true)
+    // Every word survives, in order.
+    expect(sentences.flatMap((s) => s.words)).toEqual(words)
+  })
+
+  it('leaves a ramble whole when it has no pause worth splitting at', () => {
+    const words = Array.from({ length: 60 }, (_, i) => ({ text: 'w', start: i * 0.5, end: i * 0.5 + 0.4 }))
+    const transcript = { language: 'english', durationSec: 30, segments: [{ id: 0, text: 'x', start: 0, end: 30, words }] }
+    expect(transcriptSentences(transcript)).toHaveLength(1)
+  })
+
+  it('averages segment energy into each sentence by word duration', () => {
+    const t = makeTranscript(['Loud line here.', 'quiet line here.'])
+    t.segments[0].energy = 0.9
+    t.segments[1].energy = 0.1
+    const [loud, quiet] = transcriptSentences(t)
+    expect(loud.energy).toBe(0.9)
+    expect(quiet.energy).toBe(0.1)
+    const none = transcriptSentences(makeTranscript(['no energy.']))
+    expect(none[0].energy).toBeUndefined()
+  })
+})
+
+describe('sentenceAt / sentencesInRange', () => {
+  const sentences = transcriptSentences(twoSentences())
+
+  it('finds the sentence a moment falls inside and null in gaps', () => {
+    expect(sentenceAt(sentences, 0.2)?.index).toBe(0)
+    expect(sentenceAt(sentences, 1.6)?.index).toBe(1)
+    // Between "there." (ends 0.9) and "This" (starts 1.2).
+    expect(sentenceAt(sentences, 1.0)).toBeNull()
+    expect(sentenceAt(sentences, 99)).toBeNull()
+  })
+
+  it('returns the sentences overlapping a range', () => {
+    expect(sentencesInRange(sentences, 0.8, 1.3).map((s) => s.index)).toEqual([0, 1])
+    expect(sentencesInRange(sentences, 1.3, 5).map((s) => s.index)).toEqual([1])
   })
 })

--- a/tests/tighten.test.ts
+++ b/tests/tighten.test.ts
@@ -36,6 +36,33 @@ describe('computeKeptSegments', () => {
     expect(segments!.some((s) => mid >= s.start && mid <= s.end)).toBe(false)
   })
 
+  it('keeps room for the audio fade after the last word and a beat before the first', () => {
+    // A long pause to cut, then the clip runs a full second past the last word.
+    const transcript = makeTranscript(['first thought ends here', 'second thought lands'], {
+      sentenceGapSec: 3
+    })
+    const words = transcript.segments.flatMap((s) => s.words)
+    const first = words[0]
+    const last = words[words.length - 1]
+    const clipStart = Math.max(0, first.start - 1)
+    const clipEnd = last.end + 1
+    const segments = computeKeptSegments(transcript, clipStart, clipEnd)!
+    expect(segments[0].start).toBeCloseTo(Math.max(clipStart, first.start - 0.3), 5)
+    // 0.7 s of tail: the export's 0.4 s fade sits entirely after the speech.
+    expect(segments[segments.length - 1].end).toBeCloseTo(last.end + 0.7, 5)
+  })
+
+  it('never extends head or tail room beyond the clip itself', () => {
+    const transcript = makeTranscript(['first thought ends here', 'second thought lands'], {
+      sentenceGapSec: 3
+    })
+    const words = transcript.segments.flatMap((s) => s.words)
+    const last = words[words.length - 1]
+    const segments = computeKeptSegments(transcript, words[0].start + 0.1, last.end + 0.2)!
+    expect(segments[0].start).toBeCloseTo(words[0].start + 0.1, 5)
+    expect(segments[segments.length - 1].end).toBeCloseTo(last.end + 0.2, 5)
+  })
+
   it('returns null for clips with fewer than three words', () => {
     const transcript = makeTranscript(['hi there'])
     expect(computeKeptSegments(transcript, 0, transcript.durationSec)).toBeNull()

--- a/tests/transcribe.test.ts
+++ b/tests/transcribe.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest'
-import { stitchChunkResults, type ChunkResult } from '../src/main/pipeline/transcribe'
+import {
+  isHallucinatedSegment,
+  MIN_WORD_SEC,
+  normalizeWordTimings,
+  stitchChunkResults,
+  trustedChunkText,
+  type ChunkResult
+} from '../src/main/pipeline/transcribe'
 import type { AudioChunk } from '../src/main/pipeline/ffmpeg'
-import type { WhisperResponse } from '../src/main/pipeline/openai'
+import type { WhisperResponse, WhisperSegment } from '../src/main/pipeline/openai'
 
 function chunk(offsetSec: number, keepFromSec: number, keepToSec: number): AudioChunk {
   return { path: `/tmp/a-${offsetSec}.mp3`, offsetSec, keepFromSec, keepToSec }
@@ -111,5 +118,134 @@ describe('stitchChunkResults', () => {
     ]
     const t = stitchChunkResults(results)
     expect(t.segments[0].words.map((w) => w.text)).toEqual(['ok'])
+  })
+})
+
+describe('isHallucinatedSegment', () => {
+  const seg = (extra: Partial<WhisperSegment>): WhisperSegment => ({
+    id: 0,
+    text: 'x',
+    start: 0,
+    end: 1,
+    ...extra
+  })
+
+  it('trusts segments without diagnostics', () => {
+    expect(isHallucinatedSegment(seg({}))).toBe(false)
+  })
+
+  it('flags silence-with-low-confidence text, as Whisper itself does', () => {
+    expect(isHallucinatedSegment(seg({ no_speech_prob: 0.9, avg_logprob: -1.4 }))).toBe(true)
+  })
+
+  it('keeps a confident transcription even when no-speech probability is high', () => {
+    // Quiet but clear speech: the decoder is sure of the words.
+    expect(isHallucinatedSegment(seg({ no_speech_prob: 0.9, avg_logprob: -0.3 }))).toBe(false)
+  })
+
+  it('keeps low-confidence text that is clearly speech', () => {
+    expect(isHallucinatedSegment(seg({ no_speech_prob: 0.1, avg_logprob: -1.4 }))).toBe(false)
+  })
+
+  it('flags looped output by compression ratio regardless of the other signals', () => {
+    expect(isHallucinatedSegment(seg({ compression_ratio: 3.1, no_speech_prob: 0.05, avg_logprob: -0.2 }))).toBe(true)
+    expect(isHallucinatedSegment(seg({ compression_ratio: 1.6 }))).toBe(false)
+  })
+})
+
+describe('stitchChunkResults hallucination filtering', () => {
+  it('drops hallucinated segments and the words inside them', () => {
+    const res: WhisperResponse = {
+      language: 'english',
+      duration: 20,
+      text: 'real words Thank you for watching',
+      words: [
+        { word: 'real', start: 1, end: 1.3 },
+        { word: 'words', start: 1.4, end: 1.8 },
+        { word: 'Thank', start: 10, end: 10.3 },
+        { word: 'you', start: 10.4, end: 10.6 },
+        { word: 'for', start: 10.7, end: 10.9 },
+        { word: 'watching', start: 11, end: 11.5 }
+      ],
+      segments: [
+        { id: 0, text: 'real words', start: 1, end: 1.8, no_speech_prob: 0.02, avg_logprob: -0.2 },
+        {
+          id: 1,
+          text: 'Thank you for watching',
+          start: 9.5,
+          end: 12,
+          no_speech_prob: 0.93,
+          avg_logprob: -1.6
+        }
+      ]
+    }
+    const t = stitchChunkResults([{ chunk: chunk(0, 0, Number.POSITIVE_INFINITY), res }])
+    expect(t.segments.map((s) => s.text)).toEqual(['real words'])
+    expect(t.segments.flatMap((s) => s.words.map((w) => w.text))).toEqual(['real', 'words'])
+  })
+
+  it('primes the next chunk with trusted text only', () => {
+    const res: WhisperResponse = {
+      language: 'english',
+      duration: 20,
+      text: 'good stuff Subtitles by Amara',
+      segments: [
+        { id: 0, text: ' good stuff ', start: 0, end: 2 },
+        { id: 1, text: 'Subtitles by Amara', start: 15, end: 18, no_speech_prob: 0.8, avg_logprob: -1.2 }
+      ]
+    }
+    expect(trustedChunkText(res)).toBe('good stuff')
+  })
+
+  it('falls back to the plain text when a response has no segments', () => {
+    expect(trustedChunkText({ language: 'english', duration: 1, text: 'hi there' })).toBe('hi there')
+  })
+})
+
+describe('normalizeWordTimings', () => {
+  it('gives zero-length words a visible duration inside the gap before the next word', () => {
+    const words = normalizeWordTimings([
+      { text: 'a', start: 1, end: 1 },
+      { text: 'b', start: 2, end: 2.3 }
+    ])
+    expect(words[0].end).toBeCloseTo(1.15)
+    expect(words[0].end).toBeLessThanOrEqual(words[1].start)
+  })
+
+  it('repairs a word that ends before it starts', () => {
+    const [w] = normalizeWordTimings([{ text: 'a', start: 5, end: 4.8 }])
+    expect(w.end).toBeGreaterThanOrEqual(w.start + MIN_WORD_SEC)
+  })
+
+  it('removes overlaps so each word starts where the previous one ends', () => {
+    const words = normalizeWordTimings([
+      { text: 'a', start: 0, end: 0.6 },
+      { text: 'b', start: 0.4, end: 0.9 }
+    ])
+    expect(words[1].start).toBe(0.6)
+    expect(words[1].end).toBe(0.9)
+  })
+
+  it('never creates an empty window even in a tight cluster', () => {
+    const words = normalizeWordTimings([
+      { text: 'a', start: 1, end: 1 },
+      { text: 'b', start: 1.01, end: 1.01 },
+      { text: 'c', start: 1.02, end: 1.02 }
+    ])
+    for (let i = 0; i < words.length; i++) {
+      expect(words[i].end - words[i].start).toBeGreaterThanOrEqual(MIN_WORD_SEC - 1e-9)
+      if (i > 0) expect(words[i].start).toBeGreaterThanOrEqual(words[i - 1].end)
+    }
+  })
+
+  it('leaves clean timings untouched', () => {
+    const words = normalizeWordTimings([
+      { text: 'a', start: 0, end: 0.3 },
+      { text: 'b', start: 0.4, end: 0.7 }
+    ])
+    expect(words).toEqual([
+      { text: 'a', start: 0, end: 0.3 },
+      { text: 'b', start: 0.4, end: 0.7 }
+    ])
   })
 })


### PR DESCRIPTION
## What does this change?

A quality pass over the five things the product lives on: where clips start and stop, captions matching the preview, audio mastering, speaker reframing throughput, and cleaner transcripts. Bumps the version to 0.8.0 with a dated CHANGELOG section so the release workflow can publish notes.

**Clip boundaries**
- The model reads the transcript as one sentence per line (derived from word punctuation, unpunctuated rambles split at pauses) instead of Whisper segments, which break mid-sentence, and is told to start and end every clip on a line. The ending and opening reviews use the same sentences.
- A start inside a sentence opens that sentence rather than jumping to the nearest boundary; an end inside a sentence completes it.
- Tightened clips keep 0.7 s after the last word so the export fade no longer ducks the final syllable.
- New `scripts/eval-clips.ts` measures boundary quality on saved projects, and with `--rerun` compares against fresh detection so prompt changes can be checked.

**Captions**
- Groups are laid out into explicit lines from a per-style em budget (measured glyph widths, aspect-aware), capped at two lines. The ASS export carries the breaks as `\N` with `\q2` on caption events; the preview draws one non-wrapping block per line. Preview and export cannot wrap differently.
- Caption events are anchored middle-centre on the style line, matching the preview. Two-line captions used to sit half a block higher in the export.
- Finished groups hold for up to 1.5 s instead of blanking the frame on every pause.

**Audio**
- Two-pass loudness: measure, then one linear gain. Through loudnorm linear mode when peaks allow (range target raised to the measured range, which that mode requires), otherwise a plain gain into a true-peak limiter. Single-pass dynamic only when the source cannot be measured.

**Reframe throughput**
- Face tracking plus active speaker detection runs for the top tier only (eight clips, twelve for scores of 80+). The rest are analysed on demand when opened or exported, with refcounted cancellation and an editor status line with retry. Layout choices made while pending are kept.

**Transcripts**
- Whisper segments it flags as hallucinations are dropped with their words and never primed into the next chunk. Word timings are made monotonic with a minimum on-screen duration.

**Also**
- The "fit under N MB" field can be cleared and retyped; it commits on blur/Enter.

## Why?

Making a long video into clips is judged in the first and last second of each clip and by whether the captions look like the editor promised. Each of these was leaking quality in a way you could see or hear: mid-sentence cuts, captions wrapping differently in the file, audio pumping on speech, an hour of face tracking before the first clip appeared.

## How did you test it?

- [x] `npm test` (324 tests, up from 231; new coverage for sentence derivation, boundary snapping, caption layout and anchor, loudness parsing and both paths, tier selection and merge rules, hallucination filtering, word timing repair)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Checked the change in the running app (Xvfb smoke test with screenshots)
- [x] Offline pipeline and quality scripts (real renders through the new audio chain)
- [x] A scripted-model test drives the whole highlight pass end to end through a stubbed network layer: sentence-per-line prompt, mid-sentence model boundaries landing on sentence boundaries, the ending review extending a clip, the opening review advancing one, dedupe and clamping.
- [x] An integration test runs the real on-demand reframe analysis on a synthetic video under a stubbed Electron, covering persistence, shared runs, cancellation refcounting and merging with concurrent edits.
- [x] Loudness verified on the bundled ffmpeg: a wide-range source lands at -14.0 LUFS in linear mode; a peak-limited source lands at -14.5 LUFS with the true peak at -1.9 dBTP through the limiter.
- [x] Rendered 9:16 frames for three caption styles and a long hook title and checked them visually: blocks centred on their anchors, explicit two-line breaks, the hook wrapping inside its margins.

## Anything to watch out for?

Preview and export still share the planning code in `src/shared/`; the caption layout now lives there too (`captionLayout.ts`), so both sides get identical lines by construction. The width estimate is deliberately conservative for unknown uploaded fonts, so lines break a little early rather than risk overflow.

Older projects load unchanged: clips without a reframe status are treated as already analysed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZCKJpD6vn9eFsymhmhHhg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZCKJpD6vn9eFsymhmhHhg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches highlight detection, render audio, export IPC, and on-demand reframe on the critical path; behavior is heavily tested but regressions in framing or loudness would affect every export.
> 
> **Overview**
> **0.8.0** is a quality pass on clip boundaries, captions, export audio, reframe throughput, and transcript hygiene.
> 
> **Clip picking** now feeds the model **one sentence per line** (from word punctuation, with long unpunctuated runs split at pauses) instead of Whisper segments, and snaps starts/ends with **`snapClipStart` / `snapClipEnd`** so clips open and close on thoughts. Opening/ending reviews use the same sentence model. **Tighten** keeps more head/tail room so the export fade does not duck the last syllable. **`scripts/eval-clips.ts`** scores saved projects and can **`--rerun`** detection for prompt A/B checks.
> 
> **Speaker reframing** runs eagerly only for the **top 8–12** clips; others stay **`reframeStatus: pending`** until the editor opens them or export runs **`ensureClipReframe`**, with merge rules so stale renderer saves do not wipe analysis and concurrent callers share one run.
> 
> **Captions** share a width-based **`captionLayoutBudget`** in `captionLayout.ts` for preview and ASS (`\N` + `\q2`), middle-centre **`pos`** to match preview, and a brief **hold** after each group.
> 
> **Exports** **measure then normalize** loudness (linear loudnorm or gain+limiter) instead of single-pass dynamic loudnorm.
> 
> **Transcription** drops **hallucinated** Whisper segments and words, primes chunks with **trusted** text only, and **normalizes** word timings for karaoke.
> 
> Also fixes the **fit under N MB** settings field (draft until blur/Enter) and bumps version/docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b89e0ac5f57f8bbac4e721b8e343cecda4e67e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->